### PR TITLE
Implement Warden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist-newstyle
 tags
+tmp

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Control.Concurrent (MVar, modifyMVar, newMVar)
 import Control.Concurrent.Async (concurrently_, replicateConcurrently_, forConcurrently_)
-import Control.Exception (ErrorCall(..), throwIO, onException)
+import Control.Exception (ErrorCall(..), throwIO)
 import qualified Data.HashMap.Strict as HashMap
 import Control.Monad (replicateM_, forM_)
 import qualified Data.Text as Text
@@ -125,7 +125,7 @@ benchTopic preFilled msgs = Criterion.bgroup "topic" $
   readFrom topic group n =
     T.withConsumer topic group $ \consumer ->
     forM_ [1.. n] $ \k -> do
-      r <- T.read consumer `onException` putStrLn "read failure"
+      r <- T.read consumer
       case r of
         Right _ -> return ()
         Left e -> throwIO $ ErrorCall $ "unexpected read at " <> show k <> ": " <> show e

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -2,7 +2,7 @@ module Main where
 
 import Control.Concurrent (MVar, modifyMVar, newMVar)
 import Control.Concurrent.Async (concurrently_, replicateConcurrently_, forConcurrently_)
-import Control.Exception (ErrorCall(..), throwIO)
+import Control.Exception (ErrorCall(..), throwIO, onException)
 import qualified Data.HashMap.Strict as HashMap
 import Control.Monad (replicateM_, forM_)
 import qualified Data.Text as Text
@@ -125,7 +125,7 @@ benchTopic preFilled msgs = Criterion.bgroup "topic" $
   readFrom topic group n =
     T.withConsumer topic group $ \consumer ->
     forM_ [1.. n] $ \k -> do
-      r <- T.read consumer
+      r <- T.read consumer `onException` putStrLn "read failure"
       case r of
         Right _ -> return ()
         Left e -> throwIO $ ErrorCall $ "unexpected read at " <> show k <> ": " <> show e

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -22,6 +22,7 @@ import qualified Ambar.Emulator.Queue.Partition as P
 import Ambar.Emulator.Queue.Partition.File (FilePartition)
 import qualified Ambar.Emulator.Queue.Partition.File as F
 import Utils.Some (Some(..))
+import Utils.Warden as Warden
 
 main :: IO ()
 main =
@@ -184,10 +185,9 @@ withFileTopic :: PartitionCount -> (Topic -> IO a) -> IO a
 withFileTopic (PartitionCount n) act =
   withTempPath $ \path ->
   withMany (f path) [0..n-1] $ \pinstances ->
-  T.withTopic
-    (HashMap.fromList $ zip [0..] pinstances)
-    mempty
-    act
+  Warden.withWarden $ \warden -> do
+  let groups = HashMap.fromList $ zip [0..] pinstances
+  T.withTopic warden groups mempty act
   where
   f path pnumber g = do
     F.withFilePartition path (show pnumber) (g . Some)

--- a/emulator.cabal
+++ b/emulator.cabal
@@ -95,6 +95,7 @@ test-suite emulator-tests
         Test.Connector
         Test.Emulator
         Test.OnDemand
+        Test.Warden
         Test.Utils.OnDemand
     type:    exitcode-stdio-1.0
     build-depends:

--- a/emulator.cabal
+++ b/emulator.cabal
@@ -56,6 +56,7 @@ library emulator-lib
         Utils.Prettyprinter
         Utils.STM
         Utils.Some
+        Utils.Warden
     build-depends:
         base ^>=4.17.2.1
         , aeson

--- a/emulator.cabal
+++ b/emulator.cabal
@@ -94,7 +94,7 @@ test-suite emulator-tests
         Test.Queue
         Test.Connector
         Test.Emulator
-        Test.Utils.Tests
+        Test.OnDemand
         Test.Utils.OnDemand
     type:    exitcode-stdio-1.0
     build-depends:

--- a/src/Ambar/Emulator/Queue.hs
+++ b/src/Ambar/Emulator/Queue.hs
@@ -119,6 +119,7 @@ save (Queue store _ var) =
   -- do it in separate STM transactions to minimise retries.
   -- any offset moved during a `getState` operation
   inventory <- Inventory <$> forM topics (T.getState . d_topic)
+  -- keep the MVar during writing to prevent concurrent saves.
   inventoryWrite store inventory
 
 openTopics :: Store -> Inventory -> IO (HashMap TopicName TopicData)

--- a/src/Ambar/Emulator/Queue.hs
+++ b/src/Ambar/Emulator/Queue.hs
@@ -38,9 +38,12 @@ import Ambar.Emulator.Queue.Partition.File (FilePartition)
 import Utils.Async (withAsyncThrow)
 import Utils.Delay (every, seconds)
 import Utils.Some (Some(..))
+import Utils.Warden (Warden)
+import qualified Utils.Warden as Warden
 
 data Queue = Queue
-  { q_store :: Store
+  { q_warden :: Warden
+  , q_store :: Store
   , q_count :: PartitionCount -- ^ default number of partitions in new topics
   , q_topics :: MVar (HashMap TopicName TopicData)
   }
@@ -78,14 +81,15 @@ withQueue
   -> PartitionCount  -- ^ default partition count for new topics
   -> (Queue -> IO a) -> IO a
 withQueue path count act =
-  bracket (open (Store path) count) close $ \queue ->
+  Warden.withWarden $ \warden ->
+  bracket (open warden (Store path) count) close $ \queue ->
     withAsyncThrow (saver queue) (act queue)
   where
   saver :: Queue -> IO Void
   saver queue = every (seconds 5) (save queue)
 
-open :: Store -> PartitionCount -> IO Queue
-open store@(Store path) count = do
+open :: Warden -> Store -> PartitionCount -> IO Queue
+open warden store@(Store path) count = do
   createDirectoryIfMissing True path
   inventoryLock store
   e <- inventoryLoad store
@@ -94,16 +98,17 @@ open store@(Store path) count = do
     Left (Unreadable err) -> throwIO $ CorruptedInventory err
     Right i -> return i
 
-  topics <- openTopics store inventory
+  topics <- openTopics warden store inventory
   topicsVar <- newMVar topics
   return $ Queue
-    { q_store = store
+    { q_warden = warden
+    , q_store = store
     , q_count = count
     , q_topics = topicsVar
     }
 
 close :: Queue -> IO ()
-close queue@(Queue store _ var) =
+close queue@(Queue _ store _ var) =
   uninterruptibleMask_ $ do
   save queue
   modifyMVar var $ \topics -> do
@@ -114,7 +119,7 @@ close queue@(Queue store _ var) =
   inventoryRelease store
 
 save :: Queue -> IO ()
-save (Queue store _ var) =
+save (Queue _ store _ var) =
   withMVar var $ \topics -> do
   -- do it in separate STM transactions to minimise retries.
   -- any offset moved during a `getState` operation
@@ -122,11 +127,11 @@ save (Queue store _ var) =
   -- keep the MVar during writing to prevent concurrent saves.
   inventoryWrite store inventory
 
-openTopics :: Store -> Inventory -> IO (HashMap TopicName TopicData)
-openTopics store (Inventory inventory) = do
+openTopics :: Warden -> Store -> Inventory -> IO (HashMap TopicName TopicData)
+openTopics warden store (Inventory inventory) = do
   flip HashMap.traverseWithKey inventory $ \name (TopicState ps cs) -> do
     partitions <- openPartitions store name ps
-    topic <- T.openTopic (Some <$> partitions) cs
+    topic <- T.openTopic warden (Some <$> partitions) cs
     return $ TopicData topic partitions
 
 openPartitions
@@ -173,14 +178,14 @@ inventoryLoad store = do
         Right i -> Right i
 
 openTopic :: Queue -> TopicName -> IO Topic
-openTopic (Queue store (PartitionCount count) var) name =
+openTopic (Queue warden store (PartitionCount count) var) name =
   modifyMVar var $ \topics ->
   case HashMap.lookup name topics of
     Just (TopicData topic _) -> return (topics, topic)
     Nothing -> do
       let pnumbers = Set.fromList $ fmap PartitionNumber [0..count - 1]
       partitions <- openPartitions store name pnumbers
-      topic <- T.openTopic (Some <$> partitions) mempty
+      topic <- T.openTopic warden (Some <$> partitions) mempty
       let tdata = TopicData topic partitions
       return (HashMap.insert name tdata topics, topic)
 

--- a/src/Ambar/Emulator/Queue/Partition/File.hs
+++ b/src/Ambar/Emulator/Queue/Partition/File.hs
@@ -8,13 +8,20 @@ module Ambar.Emulator.Queue.Partition.File
   , WriteError(..)
   ) where
 
-import Control.Concurrent (MVar, newMVar, withMVar, modifyMVar_)
+import Control.Concurrent (MVar, newMVar, withMVarMasked, modifyMVar_)
 import qualified Control.Concurrent.STM as STM
 import Control.Concurrent.STM
   ( TVar
   , TMVar
   )
-import Control.Exception (Exception(..), bracket, bracketOnError, throwIO, uninterruptibleMask_)
+import Control.Exception
+  ( Exception(..)
+  , bracket
+  , throwIO
+  , uninterruptibleMask_
+  , mask
+  , onException
+  )
 import Control.Monad (void, unless, when)
 import qualified Data.Binary as Binary
 import Data.ByteString (ByteString)
@@ -166,6 +173,7 @@ open location name = do
 
 close :: HasCallStack => FilePartition -> IO ()
 close FilePartition{..} =
+  -- will wait if we are writing to the file
   uninterruptibleMask_ $
   modifyMVar_ p_handles $ \case
     Nothing -> return Nothing -- already closed
@@ -234,46 +242,47 @@ instance Partition FilePartition where
 
   seek :: HasCallStack => FileReader -> Position -> IO ()
   seek (FileReader _ var) pos =
-    bracketOnError acquire undo $ \(next, offset, info) -> do
-      when (next /= offset) $
-        case r_handle info of
-          Nothing ->
-            throwErr (r_partition info) "seek: closed reader."
-          Just handle -> do
-            Bytes byteOffset <- readIndexEntry (p_index $ r_partition info) offset
-            hSeek handle AbsoluteSeek (fromIntegral byteOffset)
+    withTMVarIO var $ \info ->
+    bracketOnException (acquire info) (release info) (undo info) $
+      \(next, offset, count) -> do
+        when (offset > fromIntegral count) $
+          throwErr (r_partition info) $ unwords
+            [ "seek: offset out of bounds."
+            , "Entries:", show count
+            , "Offset:", show offset
+            ]
 
-      atomicallyNamed "file.seek" $ do
-        STM.putTMVar var info
+        when (next /= offset) $
+          case r_handle info of
+            Nothing ->
+              throwErr (r_partition info) "seek: closed reader."
+            Just handle -> do
+              Bytes byteOffset <- readIndexEntry (p_index $ r_partition info) offset
+              hSeek handle AbsoluteSeek (fromIntegral byteOffset)
     where
-    acquire = atomicallyNamed "file.seek.acquire" $ do
-      info <- STM.takeTMVar var
-      (Count count, _) <- STM.readTVar $ p_info $ r_partition info
-      let offset = max 0 $ case pos of
-            At o -> o
-            Beginning -> 0
-            End -> Offset count - 1
+    acquire info =
+      atomicallyNamed "file.seek.acquire" $ do
+        (Count count, _) <- STM.readTVar $ p_info $ r_partition info
+        next <- STM.readTVar (r_next info)
+        let offset = max 0 $ case pos of
+              At o -> o
+              Beginning -> 0
+              End -> Offset count - 1
+        return (next, offset, count)
 
-      when (offset > fromIntegral count) $
-        throwErr (r_partition info) $ unwords
-          [ "seek: offset out of bounds."
-          , "Entries:", show count
-          , "Offset:", show offset
-          ]
+    release info (_, offset, _) =
+      atomicallyNamed "file.seek.release" $ do
+        STM.writeTVar (r_next info) offset
 
-      next <- STM.readTVar (r_next info)
-      STM.writeTVar (r_next info) offset
-      return (next, offset, info)
-
-    undo (next,_,info) = atomicallyNamed "file.undo" $ do
-      STM.putTMVar var info
-      STM.writeTVar (r_next info) next
+    undo info (next, _, _) =
+      atomicallyNamed "file.seek.undo" $ do
+        STM.writeTVar (r_next info) next
 
   -- | Reads one record and advances the Reader.
   -- Blocks if there are no more records.
   read :: HasCallStack => FileReader -> IO (Offset, Record)
   read (FileReader _ var) =
-    bracketOnError acquire undo $ \(len, next, info) -> do
+    bracketOnException acquire release undo $ \(_, next, info) -> do
       handle <- case r_handle info of
         Nothing -> error $ unwords
             [ "FilePartition: read: closed reader."
@@ -282,11 +291,6 @@ instance Partition FilePartition where
         Just h -> return h
 
       record <- Record <$> Char8.hGetLine handle
-
-      atomicallyNamed "file.read" $ do
-        STM.writeTVar (r_next info) (next + 1)
-        STM.putTMVar var info { r_length = len }
-
       return (next, record)
     where
       acquire = atomicallyNamed "file.read.acquire" $ do
@@ -300,14 +304,19 @@ instance Partition FilePartition where
         unless (partitionLength > fromIntegral next) STM.retry
         return (partitionLength, next, info)
 
-      undo (_,_,info) = atomicallyNamed "file.read.undo" $ STM.putTMVar var info
+      release (len, next, info) = atomicallyNamed "file.read.release" $ do
+        STM.writeTVar (r_next info) (next + 1)
+        STM.putTMVar var info { r_length = len }
+
+      undo (_, _, info) =  do
+        atomicallyNamed "file.read.undo" $ STM.putTMVar var info
 
   write :: HasCallStack => FilePartition -> Record -> IO ()
-  write (FilePartition{..}) (Record bs)  = do
+  write (FilePartition{..}) (Record bs) = do
     when (Char8.elem '\n' bs) $
       error "FilePartition write: record contains newline character"
 
-    withMVar p_handles $ \mhandles -> do
+    withMVarMasked p_handles $ \mhandles -> do
       (fd_records, fd_index) <- maybe (throwIO ClosedPartition) return mhandles
       (Count count, Bytes partitionSize) <- STM.readTVarIO p_info
 
@@ -317,8 +326,10 @@ instance Partition FilePartition where
           newCount = count + 1
           nextEntryByteOffset = B.toStrict $ Binary.encode newSize
 
-      writeFD fd_records entry
-      writeFD fd_index nextEntryByteOffset
+      uninterruptibleMask_ $ do
+        writeFD fd_records entry
+        writeFD fd_index nextEntryByteOffset
+
       atomicallyNamed "file.write" $ STM.writeTVar p_info (Count newCount, Bytes newSize)
 
 writeFD :: HasCallStack => FD -> ByteString -> IO ()
@@ -342,17 +353,35 @@ throwErr p msg =
   error $
     "FilePartition (" <> unPartitionName (p_name p) <> "): " <> msg
 
+bracketOnException
+  :: IO a          -- ^ acquire resource
+  -> (a -> IO ())  -- ^ release on success
+  -> (a -> IO ())  -- ^ release on error
+  -> (a -> IO b)   -- ^ use resource
+  -> IO b
+bracketOnException acquire release undo act =
+  mask $ \unmask -> do
+    r <- acquire
+    x <- unmask (act r) `onException` undo r
+    release r
+    return x
+
 modifyTMVarIO :: TMVar a -> (a -> IO (a, b)) -> IO b
-modifyTMVarIO var act =
-  bracketOnError
-    (atomicallyNamed "modifyTMVarIO.acquire" $ STM.takeTMVar var)
-    (atomicallyNamed "modifyTMVarIO.release" . STM.putTMVar var)
-    $ \x -> do
-      (x', y) <- act x
-      atomicallyNamed "modifyTMVarIO.put" $ STM.putTMVar var x'
-      return y
+modifyTMVarIO var act = mask $ \release -> do
+  x <- atomicallyNamed "modifyTMVarIO.acquire" $ STM.takeTMVar var
+  (x', y) <- release (act x)
+    `onException`
+    atomicallyNamed "modifyTMVarIO.release" (STM.putTMVar var x)
+  atomicallyNamed "modifyTMVarIO.put" $ STM.putTMVar var x'
+  return y
 
 modifyTMVarIO_ :: TMVar a -> (a -> IO a) -> IO ()
 modifyTMVarIO_ var act =
   modifyTMVarIO var $ fmap (,()) . act
+
+withTMVarIO :: TMVar a -> (a -> IO b) -> IO b
+withTMVarIO var act =
+  modifyTMVarIO var $ \x -> do
+    r <- act x
+    return (x, r)
 

--- a/src/Ambar/Emulator/Queue/Partition/STMReader.hs
+++ b/src/Ambar/Emulator/Queue/Partition/STMReader.hs
@@ -30,6 +30,8 @@ import Ambar.Emulator.Queue.Partition
   , Position(..)
   )
 import Utils.STM (atomicallyNamed)
+import qualified Utils.Warden as Warden
+import Utils.Warden (Warden)
 
 import qualified Ambar.Emulator.Queue.Partition as Partition
 
@@ -57,10 +59,11 @@ destroy STMReader{..} = Async.cancel r_worker
 
 new
   :: Partition a
-  => a
+  => Warden
+  -> a
   -> Offset  -- ^ variable we will use to keep track of comitted offsets
   -> IO STMReader
-new partition start = do
+new warden partition start = do
   reader <- Partition.openReader partition
   expectedVar <- STM.newTVarIO start
   nextVar <- STM.newEmptyTMVarIO
@@ -109,7 +112,7 @@ new partition start = do
 
   -- TODO: Errors from this worker are swalloed.
   -- We MUST implement something to make the whole queue seize-up.
-  worker <- Async.async (work 0 `finally` cleanup)
+  worker <- Warden.spawnLinked warden (work 0 `finally` cleanup)
   return STMReader
     { r_worker = worker
     , r_next = nextVar

--- a/src/Utils/Delay.hs
+++ b/src/Utils/Delay.hs
@@ -2,7 +2,7 @@ module Utils.Delay
   ( Duration
   , delay
   , every
-  , timeout
+  , deadline
   , hang
   , seconds
   , millis
@@ -11,9 +11,11 @@ module Utils.Delay
   , toDiffTime
   ) where
 
+import Control.Exception (Exception, throwIO)
 import Control.Concurrent (threadDelay)
 import Control.Monad (forever)
 import Data.Time.Clock (NominalDiffTime, nominalDiffTimeToSeconds, secondsToNominalDiffTime)
+import Data.Typeable (Typeable)
 import Data.Void (Void)
 import qualified System.Timeout as T
 
@@ -44,12 +46,16 @@ every period act = forever $ do
   delay period
   act
 
+data TimedOut = TimedOut
+  deriving (Show, Eq, Typeable)
+  deriving anyclass (Exception)
+
 -- | Version of timeout that throws on timeout
-timeout :: Duration -> IO a -> IO a
-timeout time act = do
+deadline :: Duration -> IO a -> IO a
+deadline time act = do
   r <- T.timeout (toMicro time) act
   case r of
-    Nothing -> error "timed out"
+    Nothing -> throwIO TimedOut
     Just v -> return v
 
 -- | Never return

--- a/src/Utils/Delay.hs
+++ b/src/Utils/Delay.hs
@@ -3,6 +3,7 @@ module Utils.Delay
   , delay
   , every
   , timeout
+  , hang
   , seconds
   , millis
   , micros
@@ -50,3 +51,7 @@ timeout time act = do
   case r of
     Nothing -> error "timed out"
     Just v -> return v
+
+-- | Never return
+hang :: IO a
+hang = forever $ threadDelay maxBound

--- a/src/Utils/Warden.hs
+++ b/src/Utils/Warden.hs
@@ -2,6 +2,7 @@ module Utils.Warden
   ( Warden
   , withWarden
   , spawn
+  , spawn_
   , spawnMask
   , spawnLinked
   , spawnLinkedMask
@@ -85,6 +86,9 @@ spawnMask (Warden _ v) act =
 
 spawn :: Warden -> IO a -> IO (Async a)
 spawn w act = spawnMask w $ \unmask -> unmask act
+
+spawn_ :: Warden -> IO a -> IO ()
+spawn_ w act = void $ spawn w act
 
 -- | Make a thread's exceptions seize-up the entire Warden computation.
 spawnLinkedMask :: Warden -> ((forall b. IO b -> IO b) -> IO a) -> IO (Async a)

--- a/src/Utils/Warden.hs
+++ b/src/Utils/Warden.hs
@@ -35,7 +35,7 @@ withWarden f = bracket create shutdown $ \warden ->
 
   shutdown :: Warden -> IO ()
   shutdown (Warden _ v) = do
-    masyncs <- swapMVar v Nothing
+    masyncs <- uninterruptibleMask_ $ swapMVar v Nothing
     forM_ masyncs $ mapConcurrently cancel . HashSet.toList
 
   monitor :: Warden -> IO ()

--- a/src/Utils/Warden.hs
+++ b/src/Utils/Warden.hs
@@ -1,0 +1,77 @@
+module Utils.Warden
+  ( Warden
+  , withWarden
+  , spawn
+  , spawnMask
+  , spawnLinked
+  , spawnLinkedMask
+  ) where
+
+import Control.Concurrent
+import Control.Concurrent.Async (Async, cancel, mapConcurrently, async, AsyncCancelled(..), asyncWithUnmask)
+import Control.Exception
+import Control.Monad
+import Data.HashSet (HashSet)
+import qualified Data.HashSet as HashSet
+import System.IO (fixIO)
+
+import Utils.Async (withAsyncThrow)
+
+-- | A Warden is an owner of Asyncs which cancels them on shutdown
+-- and can propagate exceptions from children to parent.
+--
+-- 'Nothing' in the MVar means the 'Warden' has been shut down.
+data Warden = Warden
+  { childException :: MVar SomeException
+  , _asyncs :: MVar (Maybe (HashSet (Async ())))
+  }
+
+withWarden :: (Warden -> IO a) -> IO a
+withWarden f = bracket create shutdown $ \warden ->
+  withAsyncThrow (monitor warden) $ f warden
+  where
+  create :: IO Warden
+  create = Warden <$> newEmptyMVar <*> newMVar (Just mempty)
+
+  shutdown :: Warden -> IO ()
+  shutdown (Warden _ v) = do
+    masyncs <- swapMVar v Nothing
+    forM_ masyncs $ mapConcurrently cancel . HashSet.toList
+
+  monitor :: Warden -> IO ()
+  monitor warden =
+    handle (\BlockedIndefinitelyOnMVar -> return ()) $ do
+    ex <- takeMVar (childException warden)
+    throwIO ex
+
+spawnMask :: Warden -> ((forall b. IO b -> IO b) -> IO a) -> IO (Async a)
+spawnMask (Warden _ v) act =
+  modifyMVar v $ \mas -> do
+    a <- case mas of
+      Nothing -> async (throwIO AsyncCancelled)
+      Just _ -> fixIO $ \a -> mask_ $
+        asyncWithUnmask $ \unmask ->
+          act unmask `finally` forget a
+    return (fmap (HashSet.insert (void a)) mas, a)
+  where
+  forget a = modifyMVar_ v $ return . fmap (HashSet.delete (void a))
+
+spawn :: Warden -> IO a -> IO (Async a)
+spawn w act = spawnMask w $ \unmask -> unmask act
+
+-- | Make a thread's exceptions seize-up the entire Warden computation.
+spawnLinkedMask :: Warden -> ((forall b. IO b -> IO b) -> IO a) -> IO (Async a)
+spawnLinkedMask w f = spawnMask w $ \unmask -> f unmask `catch` throwUp
+  where
+  throwUp :: SomeException -> IO a
+  throwUp ex
+    | Just AsyncCancelled <- fromException ex = throwIO ex
+    | otherwise = do
+      -- we use tryPutMVar here because we don't want the thread to be
+      -- stuck if it receives an exception during warden shutdown.
+      void $ tryPutMVar (childException w) ex
+      throwIO ex
+
+spawnLinked :: Warden -> IO a -> IO (Async a)
+spawnLinked w act = spawnLinkedMask w $ \unmask -> unmask act
+

--- a/src/Utils/Warden.hs
+++ b/src/Utils/Warden.hs
@@ -107,4 +107,3 @@ spawnLinkedMask w f = spawnMask w $ \unmask -> f unmask `catch` throwUp
 
 spawnLinked :: Warden -> IO a -> IO (Async a)
 spawnLinked w act = spawnLinkedMask w $ \unmask -> unmask act
-

--- a/src/Utils/Warden.hs
+++ b/src/Utils/Warden.hs
@@ -8,9 +8,36 @@ module Utils.Warden
   ) where
 
 import Control.Concurrent
-import Control.Concurrent.Async (Async, cancel, mapConcurrently, async, AsyncCancelled(..), asyncWithUnmask)
+  ( MVar
+  , modifyMVar
+  , modifyMVar_
+  , newEmptyMVar
+  , newMVar
+  , swapMVar
+  , takeMVar
+  , tryPutMVar
+  )
+import Control.Concurrent.Async
+  ( Async
+  , AsyncCancelled(..)
+  , async
+  , asyncWithUnmask
+  , cancel
+  , mapConcurrently
+  )
 import Control.Exception
-import Control.Monad
+  ( SomeException
+  , BlockedIndefinitelyOnMVar(..)
+  , bracket
+  , catch
+  , finally
+  , fromException
+  , handle
+  , mask_
+  , throwIO
+  , uninterruptibleMask_
+  )
+import Control.Monad (forM_, void)
 import Data.HashSet (HashSet)
 import qualified Data.HashSet as HashSet
 import System.IO (fixIO)

--- a/tests/Test/Emulator.hs
+++ b/tests/Test/Emulator.hs
@@ -33,7 +33,7 @@ import qualified Test.Connector as C
 import Test.Utils.OnDemand (OnDemand)
 import qualified Test.Utils.OnDemand as OnDemand
 import Utils.Async (withAsyncThrow)
-import Utils.Delay (timeout, seconds)
+import Utils.Delay (deadline, seconds)
 import Utils.Logger (plainLogger, Severity(..))
 
 testEmulator :: OnDemand PostgresCreds -> Spec
@@ -46,7 +46,7 @@ testEmulator p = describe "emulator" $ do
           events = addIds $ take 10 $ head mocks
       insert events
       withAsyncThrow (emulate logger config env) $
-        timeout (seconds 5) $ do
+        deadline (seconds 5) $ do
         consumed <- consume out (length events)
         consumed `shouldBe` events
 
@@ -85,7 +85,7 @@ testEmulator p = describe "emulator" $ do
 
     -- read from projected output
     consume out n =
-      timeout (seconds 3) $ do
+      deadline (seconds 3) $ do
       xs <- atomically $ do
         xs <- readTVar out
         unless (length xs >= n) retry

--- a/tests/Test/OnDemand.hs
+++ b/tests/Test/OnDemand.hs
@@ -10,7 +10,6 @@ import Test.Hspec
 import Test.Hspec.Expectations.Contrib (annotate)
 
 import Control.Concurrent.Async
-import Control.Monad
 import Control.Exception
 
 import Control.Concurrent.STM (newTVarIO, atomically, readTVarIO, modifyTVar)
@@ -18,7 +17,7 @@ import Data.Maybe (isJust)
 import qualified Test.Utils.OnDemand as OnDemand
 import System.Mem (performMajorGC)
 
-import Utils.Delay (delay, millis)
+import Utils.Delay (delay, millis, deadline)
 
 testOnDemand :: Spec
 testOnDemand = do
@@ -78,24 +77,18 @@ testOnDemand = do
         let err = "Fake Error"
         r <- OnDemand.lazy $ \_ -> throwIO (ErrorCall err)
 
-        [t1, t2] <- replicateM 2 $ async $
-          OnDemand.with r return
-
-        delay (millis 10)
-        forM_ (zip @Int [0..] [t1, t2]) $ \(n, t) -> do
-          outcome <- poll t
-          annotate ("thread " <> show n) $
-            case outcome  of
-              Just (Left e)
-                | Just (ErrorCall msg) <- fromException e
-                , msg == err -> return ()
-                | otherwise ->
-                  expectationFailure (show e)
-              Just (Right _) ->
-                  expectationFailure "unexpected success"
-              Nothing -> do
-                  cancel t
-                  expectationFailure "thread not finished"
+        forConcurrently_ ([1..3] :: [Int]) $ \n ->
+          withAsync (OnDemand.with r return) $ \t -> do
+            outcome <- deadline (millis 50) $ waitCatch t
+            annotate ("thread " <> show n) $
+              case outcome  of
+                Left e
+                  | Just (ErrorCall msg) <- fromException e
+                  , msg == err -> return ()
+                  | otherwise ->
+                    expectationFailure (show e)
+                Right _ ->
+                    expectationFailure "unexpected success"
 
     describe "withLazy" $ do
       it "ensures cleanup is run before returning" $

--- a/tests/Test/OnDemand.hs
+++ b/tests/Test/OnDemand.hs
@@ -1,4 +1,4 @@
-module Test.Utils.Tests (testUtils) where
+module Test.OnDemand (testOnDemand) where
 
 import Test.Hspec
   ( Spec
@@ -20,8 +20,8 @@ import System.Mem (performMajorGC)
 
 import Utils.Delay (delay, millis)
 
-testUtils :: Spec
-testUtils = do
+testOnDemand :: Spec
+testOnDemand = do
   describe "OnDemand" $ do
     describe "lazy" $ do
       it "doesn't instantiate if `with` is not called" $

--- a/tests/Test/Queue.hs
+++ b/tests/Test/Queue.hs
@@ -325,6 +325,7 @@ testTopic with = do
     withProducer topic f =
       T.withProducer topic (T.modPartitioner fst) (unRecord . snd) f
 
+-- | A type of partition that always fails to be read.
 data FailPartition = FailPartition
   deriving (Show, Eq, Typeable, Exception)
 

--- a/tests/Test/Queue.hs
+++ b/tests/Test/Queue.hs
@@ -3,7 +3,7 @@ module Test.Queue (testQueues, withFileTopic) where
 import Prelude hiding (read)
 
 import Control.Concurrent.Async (concurrently)
-import Control.Exception (fromException)
+import Control.Exception (fromException, Exception, throwIO)
 import Control.Monad (replicateM, forM_, replicateM_)
 import Data.ByteString (ByteString)
 import Data.Char (isAscii)
@@ -14,6 +14,7 @@ import qualified Data.HashMap.Strict as HashMap
 import qualified Data.Text as Text
 import Data.Foldable (traverse_)
 import qualified Data.Text.Encoding as Text
+import Data.Typeable (Typeable)
 import System.IO.Temp (withSystemTempDirectory)
 import Test.Hspec
   ( Spec
@@ -45,7 +46,7 @@ import qualified Ambar.Emulator.Queue.Partition as P
 import qualified Ambar.Emulator.Queue.Partition.File as FilePartition
 import Utils.Async (withAsyncThrow)
 import Utils.Some (Some(..))
-import Utils.Delay (delay, millis)
+import Utils.Delay (delay, deadline, seconds, millis, hang)
 import Utils.Warden (withWarden)
 
 testQueues :: Spec
@@ -63,13 +64,14 @@ testQueues = do
 withFileTopic :: PartitionCount -> (Topic -> IO a) -> IO a
 withFileTopic (PartitionCount n) act =
   withTempPath $ \path ->
-  withMany (f path) [0..n-1] $ \pinstances ->
+  withMany (f path) [0..PartitionNumber n-1] $ \pinstances ->
   withWarden $ \warden -> do
-  let groups = HashMap.fromList $ zip [0..] pinstances
+  let groups = HashMap.fromList pinstances
   withTopic warden groups mempty act
   where
   f path pnumber g = do
-    FilePartition.withFilePartition path (show pnumber) (g . Some)
+    FilePartition.withFilePartition path (show pnumber) $ \partition ->
+      g (pnumber, Some partition)
 
 withTempPath :: (FilePath -> IO a) -> IO a
 withTempPath = withSystemTempDirectory "partition-XXXXX"
@@ -292,6 +294,17 @@ testTopic with = do
             metaOffset (Meta _ o) = o
         sort (metaOffset <$> metas) `shouldBe` [0,1,2,2]
         sort (metaPartition <$> metas) `shouldBe` [0,0,0,1]
+
+  it "stops everything if parition reader throws" $ do
+    let groups = HashMap.singleton 0 (Some FailPartition)
+        run =
+          deadline (seconds 1) $
+          withWarden $ \warden ->
+          withTopic warden groups mempty $ \topic ->
+          T.withConsumer topic group $ \consumer -> do
+            _ <- T.read consumer
+            hang
+    run `shouldThrow` ((== Just FailPartition) . fromException)
   where
     mmeta :: Either ReadError (ByteString, Meta) -> Meta
     mmeta = \case
@@ -311,6 +324,17 @@ testTopic with = do
 
     withProducer topic f =
       T.withProducer topic (T.modPartitioner fst) (unRecord . snd) f
+
+data FailPartition = FailPartition
+  deriving (Show, Eq, Typeable, Exception)
+
+instance Partition FailPartition where
+  type Reader FailPartition = ()
+  openReader _ = return ()
+  closeReader _ = return ()
+  seek _ _ = return ()
+  read _ = throwIO FailPartition
+  write _ _ = return ()
 
 testPartition :: Partition a => (forall b. FilePath -> (a -> IO b) -> IO b) -> Spec
 testPartition with = do

--- a/tests/Test/Queue.hs
+++ b/tests/Test/Queue.hs
@@ -46,6 +46,7 @@ import qualified Ambar.Emulator.Queue.Partition.File as FilePartition
 import Utils.Async (withAsyncThrow)
 import Utils.Some (Some(..))
 import Utils.Delay (delay, millis)
+import Utils.Warden (withWarden)
 
 testQueues :: Spec
 testQueues = do
@@ -63,10 +64,9 @@ withFileTopic :: PartitionCount -> (Topic -> IO a) -> IO a
 withFileTopic (PartitionCount n) act =
   withTempPath $ \path ->
   withMany (f path) [0..n-1] $ \pinstances ->
-  withTopic
-    (HashMap.fromList $ zip [0..] pinstances)
-    mempty
-    act
+  withWarden $ \warden -> do
+  let groups = HashMap.fromList $ zip [0..] pinstances
+  withTopic warden groups mempty act
   where
   f path pnumber g = do
     FilePartition.withFilePartition path (show pnumber) (g . Some)

--- a/tests/Test/Warden.hs
+++ b/tests/Test/Warden.hs
@@ -1,0 +1,12 @@
+module Test.Warden (testWarden) where
+
+import Test.Hspec
+  ( Spec
+  , it
+  , describe
+  , shouldBe
+  )
+
+testWarden :: Spec
+testWarden = describe "Warden" $ do
+  it "works" $ () `shouldBe` ()

--- a/tests/Test/Warden.hs
+++ b/tests/Test/Warden.hs
@@ -1,12 +1,69 @@
 module Test.Warden (testWarden) where
 
+import Control.Concurrent
+import qualified Control.Concurrent.Async as Async
+import Control.Exception
+import Control.Monad
 import Test.Hspec
   ( Spec
   , it
   , describe
   , shouldBe
+  , shouldThrow
   )
+import qualified Utils.Warden as Warden
+import Utils.Delay
 
 testWarden :: Spec
 testWarden = describe "Warden" $ do
-  it "works" $ () `shouldBe` ()
+  it "kills spawned on normal termination" $
+    deadline (seconds 1) $ do
+    v <- newQSem 0
+    Warden.withWarden $ \w ->
+      Warden.spawn_ w $ hang `finally` signalQSem v
+    r <- waitQSem v
+    r `shouldBe` ()
+
+  it "kills spawned on forced termination" $
+    deadline (seconds 1) $ do
+    started <- newQSem 0
+    done <- newQSem 0
+
+    let run = Warden.withWarden $ \w -> do
+          Warden.spawn_ w $ do
+            signalQSem started
+            hang `finally` signalQSem done
+          hang
+    r <- Async.withAsync run $ \task -> do
+      waitQSem started
+      Async.cancel task
+      waitQSem done
+    r `shouldBe` ()
+
+  it "spawn doesn't propagate exceptions" $ do
+    r <- Warden.withWarden $ \w -> do
+      task <- Warden.spawn w $ throwIO $ ErrorCall "self-kill"
+      void $ Async.waitCatch task
+    r `shouldBe` ()
+
+
+  it "spawnLinked propagates exceptions" $ do
+    let err = "self-kill"
+        childError e
+          | Just (ErrorCall msg) <- fromException e = msg == err
+          | otherwise = False
+        run = Warden.withWarden $ \w -> do
+          void $ Warden.spawnLinked w $ throwIO $ ErrorCall err
+          hang
+
+    run `shouldThrow`childError
+
+  it "spawnLinked doesn't propagate AsyncCancelled" $ do
+    r <- Warden.withWarden $ \w -> do
+      started <- newQSem 0
+      task <- Warden.spawn w $ signalQSem started *> hang
+      waitQSem started
+      Async.cancel task
+      void $ Async.waitCatch task
+
+    r `shouldBe` ()

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -6,7 +6,7 @@ import Test.Config (testConfig)
 import Test.Emulator (testEmulator)
 import Test.Queue (testQueues)
 import Test.Connector (testConnectors, withPostgresSQL)
-import Test.Utils.Tests (testUtils)
+import Test.OnDemand (testOnDemand)
 import qualified Test.Utils.OnDemand as OnDemand
 
 
@@ -26,6 +26,6 @@ main = do
     -- unit tests use the projector library
     testQueues
     testConnectors pcreds
-    testUtils
+    testOnDemand
     testConfig
     testEmulator pcreds

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -7,6 +7,7 @@ import Test.Emulator (testEmulator)
 import Test.Queue (testQueues)
 import Test.Connector (testConnectors, withPostgresSQL)
 import Test.OnDemand (testOnDemand)
+import Test.Warden (testWarden)
 import qualified Test.Utils.OnDemand as OnDemand
 
 
@@ -24,8 +25,9 @@ main = do
   pcreds <- OnDemand.lazy withPostgresSQL
   hspec $ parallel $ do
     -- unit tests use the projector library
-    testQueues
-    testConnectors pcreds
     testOnDemand
+    testWarden
     testConfig
+    testQueues
     testEmulator pcreds
+    testConnectors pcreds


### PR DESCRIPTION
A thread warden ensures that we never leave hanging threads and optionally allows us to propagate thread exceptions to the source thread.