### PR TITLE
Logs

### DIFF
--- a/src/Ambar/Emulator.hs
+++ b/src/Ambar/Emulator.hs
@@ -119,12 +119,9 @@ emulate logger_ config env = do
 
   project queue dest =
     withDestination dest $ \transport -> do
-    sourceTopics <- forM (d_sources dest) $ \sid -> do
-      DataSource{..} <- case Map.lookup sid (c_sources env) of
-        Nothing -> throwIO $ ErrorCall $ "missing source: " <> show sid
-        Just s -> return s
-      topic <- Queue.openTopic queue (topicName sid)
-      return (sid, s_description, topic)
+    sourceTopics <- forM (d_sources dest) $ \source -> do
+      topic <- Queue.openTopic queue (topicName $ s_id source)
+      return (source, topic)
 
     Projector.project logger_ Projection
         { p_id = projectionId (d_id dest)

--- a/src/Ambar/Emulator.hs
+++ b/src/Ambar/Emulator.hs
@@ -89,7 +89,7 @@ emulate logger_ config env = do
       Aeson.encodeFile statePath $ EmulatorState (Map.fromList states)
 
   connect queue (source, sstate) f = do
-    let logger = annotate ("source: " <> unId (s_id source)) logger_
+    let logger = annotate ("src: " <> unId (s_id source)) logger_
     topic <- Queue.openTopic queue $ topicName $ s_id source
     case s_source source of
       SourcePostgreSQL pconfig -> do

--- a/src/Ambar/Emulator/Connector/File.hs
+++ b/src/Ambar/Emulator/Connector/File.hs
@@ -18,7 +18,7 @@ import qualified Data.Text.Lazy.Encoding as Text
 
 import Ambar.Emulator.Queue.Topic (Producer, Encoder, Partitioner, modPartitioner)
 import qualified Ambar.Emulator.Queue.Topic as Topic
-import Utils.Logger (SimpleLogger, fatal)
+import Utils.Logger (SimpleLogger, fatal, logInfo)
 
 newtype FileRecord = FileRecord Json.Value
 
@@ -40,4 +40,5 @@ connect logger producer path = do
             ]
          Right v -> return v
       Topic.write producer (FileRecord value)
+      logInfo logger $ "ingested. " <> Text.decodeUtf8 line
 

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -27,14 +27,13 @@ import qualified Data.Map.Strict as Map
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Lazy.Encoding as Text (decodeUtf8)
 import Data.Void (Void)
 import Data.Word (Word64, Word16)
 import qualified Database.PostgreSQL.Simple as P
 import qualified Database.PostgreSQL.Simple.FromField as P
 import qualified Database.PostgreSQL.Simple.FromRow as P
 import GHC.Generics (Generic)
-import Utils.Prettyprinter (renderPretty, sepBy, commaSeparated)
+import Utils.Prettyprinter (renderPretty, sepBy, commaSeparated, prettyJSON)
 import Prettyprinter (pretty)
 import qualified Prettyprinter as Pretty
 
@@ -204,8 +203,6 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
           , "serial value:", prettyJSON $ serialValue row
           , "partitioning value:", prettyJSON $ partitioningValue row
           ]
-
-       prettyJSON = pretty . Text.decodeUtf8 . Aeson.encode
 
 partitioner :: Partitioner Row
 partitioner = hashPartitioner partitioningValue

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -34,7 +34,7 @@ import qualified Database.PostgreSQL.Simple.FromField as P
 import qualified Database.PostgreSQL.Simple.FromRow as P
 import GHC.Generics (Generic)
 import Utils.Prettyprinter (renderPretty, sepBy, commaSeparated, prettyJSON)
-import Prettyprinter (pretty)
+import Prettyprinter (pretty, (<+>))
 import qualified Prettyprinter as Pretty
 
 import qualified Ambar.Emulator.Connector.Poll as Poll
@@ -198,11 +198,11 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
           ]
 
        logResult row =
-        logInfo logger $ renderPretty $ Pretty.fillSep
-          ["ingested."
-          , "serial value:", prettyJSON $ serialValue row
-          , "partitioning value:", prettyJSON $ partitioningValue row
-          ]
+        logInfo logger $ renderPretty $
+          "ingested." <+> commaSeparated
+            [ "serial_value:" <+> prettyJSON (serialValue row)
+            , "partitioning_value:" <+> prettyJSON (partitioningValue row)
+            ]
 
 partitioner :: Partitioner Row
 partitioner = hashPartitioner partitioningValue

--- a/src/Ambar/Emulator/Projector.hs
+++ b/src/Ambar/Emulator/Projector.hs
@@ -69,8 +69,8 @@ project logger_ Projection{..} =
     where
       PartitionCount pcount = Topic.partitionCount topic
       logger =
-        annotate ("source:" <> unId (s_id source)) $
-        annotate ("destination:" <> unId  p_destination)
+        annotate ("src: " <> unId (s_id source)) $
+        annotate ("dst: " <> unId  p_destination)
         logger_
 
   consume logger consumer source = do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,7 @@ import Prettyprinter (pretty)
 
 import Ambar.Emulator (emulate)
 import Ambar.Emulator.Config (parseEnvConfigFile, EmulatorConfig(..))
-import Utils.Logger (plainLogger, Severity(..))
+import Utils.Logger (plainLogger, Severity(..), logInfo)
 
 _DEFAULT_PARTITIONS_PER_TOPIC :: Int
 _DEFAULT_PARTITIONS_PER_TOPIC = 10
@@ -24,14 +24,19 @@ main = do
   cmd <- O.execParser cliOptions
   case cmd of
     CmdRun{..} -> do
+      let logger = plainLogger severity
+          severity = if o_verbose then Debug else Info
+
       env <- parseEnvConfigFile o_configPath
+      logInfo @String logger "configuration loaded"
+
       queue <- maybe defaultStatePath return o_statePath
       let config = EmulatorConfig
             { c_partitionsPerTopic = fromMaybe _DEFAULT_PARTITIONS_PER_TOPIC o_partitionsPerTopic
             , c_dataPath = queue
             }
-          severity = if o_verbose then Debug else Info
-      emulate (plainLogger severity) config env
+
+      emulate logger config env
     CmdVersion ->
       print _VERSION
 

--- a/src/Utils/Logger.hs
+++ b/src/Utils/Logger.hs
@@ -87,13 +87,11 @@ data WithSeverity a = WithSeverity Severity a
 
 instance Pretty a => Pretty (WithSeverity a) where
   pretty (WithSeverity severity a) =
-    "[" <> fromString s <> "]" <+> pretty a
-    where
-    s = case severity of
-      Fatal -> "FATAL"
-      Warn -> "WARN"
-      Info -> "INFO"
-      Debug -> "DEBUG"
+    case severity of
+      Fatal -> "[FATAL]" <+> pretty a
+      Warn -> "[WARN]" <+> pretty a
+      Info -> pretty a
+      Debug -> "[DEBUG]" <+> pretty a
 
 -- ============================================================================
 -- Loggers
@@ -123,7 +121,6 @@ standardLogger = Logger $ Text.hPutStrLn stderr
 plainLogger :: Severity -> SimpleLogger
 plainLogger maxSeverity =
   filterM (\(WithSeverity s _) -> s <= maxSeverity) $
-  enhanceM withTimeStamp $
   enhance prettify $
   serialised standardLogger
 

--- a/src/Utils/Prettyprinter.hs
+++ b/src/Utils/Prettyprinter.hs
@@ -2,11 +2,14 @@ module Utils.Prettyprinter
   ( renderPretty
   , sepBy
   , commaSeparated
+  , prettyJSON
   ) where
 
+import qualified Data.Aeson as Aeson
 import Data.Text (Text)
+import Data.Text.Lazy.Encoding as Text
 import Prettyprinter.Render.Text (renderStrict)
-import Prettyprinter (Doc, layoutSmart, defaultLayoutOptions, concatWith, (<+>))
+import Prettyprinter (Doc, pretty, layoutSmart, defaultLayoutOptions, concatWith, (<+>))
 
 renderPretty :: Doc ann -> Text
 renderPretty = renderStrict . layoutSmart defaultLayoutOptions
@@ -16,3 +19,6 @@ sepBy s = concatWith (\x y -> x <+> s <+> y)
 
 commaSeparated :: [Doc ann] -> Doc ann
 commaSeparated = sepBy ","
+
+prettyJSON :: Aeson.ToJSON a => a -> Doc ann
+prettyJSON = pretty . Text.decodeUtf8 . Aeson.encode

--- a/src/Utils/Prettyprinter.hs
+++ b/src/Utils/Prettyprinter.hs
@@ -18,7 +18,7 @@ sepBy :: Doc ann -> [Doc ann] -> Doc ann
 sepBy s = concatWith (\x y -> x <+> s <+> y)
 
 commaSeparated :: [Doc ann] -> Doc ann
-commaSeparated = sepBy ","
+commaSeparated = concatWith (\x y -> x <> "," <+> y)
 
 prettyJSON :: Aeson.ToJSON a => a -> Doc ann
 prettyJSON = pretty . Text.decodeUtf8 . Aeson.encode

--- a/tests/Test/Config.hs
+++ b/tests/Test/Config.hs
@@ -107,16 +107,14 @@ testConfig = do
             type: file
             path: ./temp.file
             sources:
-              - postgres_source
-              - file_source
+              - source_1
 
           - id: dest_1
             description: my projection 1
             type: file
             path: ./temp.file
             sources:
-              - postgres_source
-              - file_source
+              - source_1
         |] `shouldThrow` errorWith "Multiple data destinations with ID"
 
     it "detects invalid sources" $ do

--- a/tests/Test/Emulator.hs
+++ b/tests/Test/Emulator.hs
@@ -103,7 +103,7 @@ testEmulator p = describe "emulator" $ do
       out <- newTVarIO []
       let dest = DataDestination
             { d_id = Id "fun"
-            , d_sources = fmap s_id sources
+            , d_sources = sources
             , d_description = "Function destination"
             , d_destination = DestinationFun $ \e -> do
                 atomically $ modifyTVar out (e:)


### PR DESCRIPTION
Fixes #13 

Here is an example connecting to two sources, one file and one Postgres table.
The example is projecting data into a destination file.

The Postgres data has `serial_value` and `partitioning_value`. The file data has no partitioning or serial info implemented.

```
$ ./utils.sh run run --data-path tmp/data --config tmp/config.yml
Up to date
configuration loaded
src: first_source | connected
src: first_source | ingested. { "one": "a", "two": 1 }
src: first_source | ingested. { "one": "b", "two": 2 }
src: first_source | ingested. { "one": "c", "two": 3 }
src: first_source | ingested. { "one": "d", "two": 4 }
src: pg_source | connected
src: pg_source | ingested. serial_value: 1, partitioning_value: 1
src: pg_source | ingested. serial_value: 2, partitioning_value: 1
src: pg_source | ingested. serial_value: 3, partitioning_value: 1
src: pg_source | ingested. serial_value: 4, partitioning_value: 1
src: pg_source | ingested. serial_value: 5, partitioning_value: 2
src: pg_source | ingested. serial_value: 6, partitioning_value: 2
src: pg_source | ingested. serial_value: 7, partitioning_value: 3
src: pg_source | ingested. serial_value: 8, partitioning_value: 2
src: pg_source | ingested. serial_value: 9, partitioning_value: 1
src: pg_source | ingested. serial_value: 10, partitioning_value: 2
src: pg_source | ingested. serial_value: 11, partitioning_value: 3
dst: file_destination | src: pg_source | sent. id: 1 aggregate_id: 1
dst: file_destination | src: pg_source | sent. id: 5 aggregate_id: 2
dst: file_destination | src: pg_source | sent. id: 7 aggregate_id: 3
dst: file_destination | src: pg_source | sent. id: 2 aggregate_id: 1
dst: file_destination | src: pg_source | sent. id: 6 aggregate_id: 2
dst: file_destination | src: pg_source | sent. id: 11 aggregate_id: 3
dst: file_destination | src: pg_source | sent. id: 3 aggregate_id: 1
dst: file_destination | src: pg_source | sent. id: 8 aggregate_id: 2
dst: file_destination | src: pg_source | sent. id: 4 aggregate_id: 1
dst: file_destination | src: pg_source | sent. id: 10 aggregate_id: 2
dst: file_destination | src: pg_source | sent. id: 9 aggregate_id: 1
```

Note that I did not add the descriptions for source and destination as that is redundant here since the source and destination IDs are not random hashes but something descriptive chosen by the user already.