### PR TITLE
Support streaming in the Polling connector

### DIFF
--- a/src/Ambar/Emulator.hs
+++ b/src/Ambar/Emulator.hs
@@ -34,7 +34,7 @@ import Ambar.Emulator.Config
   , Destination(..)
   )
 import Utils.Delay (every, seconds)
-import Utils.Logger (SimpleLogger, annotate, logInfo)
+import Utils.Logger (SimpleLogger, annotate, logInfo, logDebugAction)
 import Utils.Some (Some(..))
 import Utils.STM (atomicallyNamed)
 
@@ -83,6 +83,7 @@ emulate logger_ config env = do
           throwIO $ ErrorCall $ "Unable to decode emulator state: " <> show err
 
   save svars =
+    logDebugAction logger_ "saving state" $
     uninterruptibleMask_ $ do
       -- reading is non-blocking so should be fine to run under uninterruptibleMask
       states <- forM svars $ \(sid, svar) -> (sid,) <$> atomicallyNamed "emulator.save" svar

--- a/src/Ambar/Emulator/Connector/Poll.hs
+++ b/src/Ambar/Emulator/Connector/Poll.hs
@@ -7,7 +7,7 @@ module Ambar.Emulator.Connector.Poll
    , mark
    , boundaries
    , cleanup
-   , batched
+   , streamed
    ) where
 
 {-| General polling connector -}
@@ -48,8 +48,9 @@ data PollingConnector entry = PollingConnector
 
 type Stream a = IO (Maybe a)
 
-batched :: IO [a] -> IO (Stream a)
-batched act = do
+-- | Take a batched computation and stream its results.
+streamed :: IO [a] -> IO (Stream a)
+streamed act = do
   ref <- newIORef =<< act
   return $ do
     xs <- readIORef ref

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -165,7 +165,7 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
      where
      pc = Poll.PollingConnector
         { Poll.c_getId = entryId
-        , Poll.c_poll = run
+        , Poll.c_poll = Poll.batched . run
         , Poll.c_pollingInterval = _POLLING_INTERVAL
         , Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME
         , Poll.c_producer = producer

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -165,7 +165,7 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
      where
      pc = Poll.PollingConnector
         { Poll.c_getId = entryId
-        , Poll.c_poll = Poll.streamed . run
+        , Poll.c_poll = \boundaries -> Poll.streamed (run boundaries)
         , Poll.c_pollingInterval = _POLLING_INTERVAL
         , Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME
         , Poll.c_producer = producer
@@ -173,6 +173,7 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
 
      parser = mkParser (columns config) schema
 
+     run :: Boundaries -> IO [Row]
      run (Boundaries bs) = do
        logDebug logger query
        r <- P.queryWith parser conn (fromString query) ()

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -10,7 +10,6 @@ module Ambar.Emulator.Connector.Postgres
 
 import Control.Concurrent.STM (STM, TVar, newTVarIO, readTVar)
 import Control.Exception (Exception, bracket, throwIO, ErrorCall(..))
-import Control.Monad (forM_)
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as Aeson
 import Data.ByteString (ByteString)
@@ -38,7 +37,7 @@ import Prettyprinter (pretty, (<+>))
 import qualified Prettyprinter as Pretty
 
 import qualified Ambar.Emulator.Connector.Poll as Poll
-import Ambar.Emulator.Connector.Poll (BoundaryTracker, Boundaries(..), EntryId(..))
+import Ambar.Emulator.Connector.Poll (BoundaryTracker, Boundaries(..), EntryId(..), Stream)
 import Ambar.Emulator.Queue.Topic (Producer, Partitioner, Encoder, hashPartitioner)
 import Utils.Async (withAsyncThrow)
 import Utils.Delay (Duration, millis, seconds)
@@ -165,7 +164,7 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
      where
      pc = Poll.PollingConnector
         { Poll.c_getId = entryId
-        , Poll.c_poll = \boundaries -> Poll.streamed (run boundaries)
+        , Poll.c_poll = run
         , Poll.c_pollingInterval = _POLLING_INTERVAL
         , Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME
         , Poll.c_producer = producer
@@ -173,13 +172,16 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
 
      parser = mkParser (columns config) schema
 
-     run :: Boundaries -> IO [Row]
-     run (Boundaries bs) = do
+     run :: Boundaries -> Stream Row
+     run (Boundaries bs) acc0 emit = do
        logDebug logger query
-       r <- P.queryWith parser conn (fromString query) ()
-       logDebug logger $ "results: " <> show (length r)
-       forM_ r logResult
-       return r
+       (acc, count) <- P.foldWith parser conn (fromString query) () (acc0, 0) $
+         \(acc, !count) row -> do
+           logResult row
+           acc' <- emit acc row
+           return (acc', succ count)
+       logDebug logger $ "results: " <> show @Int count
+       return acc
        where
        query = fromString $ Text.unpack $ renderPretty $ Pretty.fillSep
           [ "SELECT" , commaSeparated $ map pretty $ columns config

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -165,7 +165,7 @@ withConnector logger (ConnectorState tracker) producer config@ConnectorConfig{..
      where
      pc = Poll.PollingConnector
         { Poll.c_getId = entryId
-        , Poll.c_poll = Poll.batched . run
+        , Poll.c_poll = Poll.streamed . run
         , Poll.c_pollingInterval = _POLLING_INTERVAL
         , Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME
         , Poll.c_producer = producer

--- a/src/Utils/Logger.hs
+++ b/src/Utils/Logger.hs
@@ -151,6 +151,13 @@ logInfo logger msg = logMsg logger (WithSeverity Info $ PrettyT $ pretty msg)
 logWarn :: (HasCallStack, Pretty a) => SimpleLogger -> a -> IO ()
 logWarn logger msg = logMsg logger (WithSeverity Warn $ PrettyT $ pretty msg)
 
+logDebugAction :: (HasCallStack) => SimpleLogger -> Text -> IO b -> IO b
+logDebugAction logger msg act = do
+  logDebug logger (msg <> ": start")
+  r <- act
+  logDebug logger (msg <> ": end")
+  return r
+
 logDebug :: (HasCallStack, Pretty a) => SimpleLogger -> a -> IO ()
 logDebug logger msg = do
   loc <- getLocation 2


### PR DESCRIPTION
We can now stream data from databases. 
It means that the amount of data we can handle in the snapshot phase is no longer constrained by the amount of RAM available.
Streaming in has been implemented in the `PostgreSQL` connector.