### PR TITLE
Multi consumers

### DIFF
--- a/src/Ambar/Emulator/Projector.hs
+++ b/src/Ambar/Emulator/Projector.hs
@@ -19,7 +19,7 @@ import Data.Maybe (listToMaybe, fromMaybe)
 import Data.String (fromString)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Control.Concurrent.Async (replicateConcurrently_, forConcurrently_)
+import Control.Concurrent.Async (forConcurrently_)
 import Control.Monad.Extra (whileM)
 import GHC.Generics (Generic)
 
@@ -63,8 +63,9 @@ project logger_ Projection{..} =
   forConcurrently_ p_sources projectSource
   where
   projectSource (source, topic) =
-    replicateConcurrently_ pcount $ -- one consumer per partition
-    Topic.withConsumer topic group $ \consumer ->
+    -- one consumer per partition
+    Topic.withConsumers topic group pcount $ \consumers ->
+    forConcurrently_ consumers $ \consumer ->
     whileM $ consume logger consumer source
     where
       PartitionCount pcount = Topic.partitionCount topic

--- a/src/Ambar/Emulator/Queue/Topic.hs
+++ b/src/Ambar/Emulator/Queue/Topic.hs
@@ -14,6 +14,7 @@ module Ambar.Emulator.Queue.Topic
   , Meta(..)
   , ReadError(..)
   , withConsumer
+  , withConsumers
   , read
   , commit
 

--- a/tests/Test/Queue.hs
+++ b/tests/Test/Queue.hs
@@ -101,17 +101,25 @@ testQueue = do
   it "restores state as it was" $
     withTempPath $ \path -> do
     let tname = TopicName "test-topic"
+    putStrLn "D state 1.."
     state1 <- Queue.withQueue path (PartitionCount 2) $ \queue -> do
       topic <- Queue.openTopic queue tname
       withProducer topic $ \producer ->
         traverse_ (T.write producer) (take 40 msgs)
 
-      T.withConsumer topic group $ \c1 ->
-        T.withConsumer topic group $ \c2 ->
+      putStrLn "D withConsumer.."
+      T.withConsumer topic group $ \c1 -> do
+        putStrLn "D withConsumer 2.."
+        T.withConsumer topic group $ \c2 -> do
+          putStrLn "D inside.."
           forM_ [c1, c2] $ \c -> do
             replicateM_ 10 $ do
+              putStrLn "D reading.."
               Right (_, meta) <- T.read c
+              print meta
               T.commit c meta
+          putStrLn "D done.."
+      putStrLn "D getting state.."
       T.getState topic
 
     state2 <- Queue.withQueue path (PartitionCount 10) $ \queue -> do

--- a/tests/Test/Queue.hs
+++ b/tests/Test/Queue.hs
@@ -101,25 +101,17 @@ testQueue = do
   it "restores state as it was" $
     withTempPath $ \path -> do
     let tname = TopicName "test-topic"
-    putStrLn "D state 1.."
     state1 <- Queue.withQueue path (PartitionCount 2) $ \queue -> do
       topic <- Queue.openTopic queue tname
       withProducer topic $ \producer ->
         traverse_ (T.write producer) (take 40 msgs)
 
-      putStrLn "D withConsumer.."
-      T.withConsumer topic group $ \c1 -> do
-        putStrLn "D withConsumer 2.."
-        T.withConsumer topic group $ \c2 -> do
-          putStrLn "D inside.."
+      T.withConsumer topic group $ \c1 ->
+        T.withConsumer topic group $ \c2 ->
           forM_ [c1, c2] $ \c -> do
             replicateM_ 10 $ do
-              putStrLn "D reading.."
               Right (_, meta) <- T.read c
-              print meta
               T.commit c meta
-          putStrLn "D done.."
-      putStrLn "D getting state.."
       T.getState topic
 
     state2 <- Queue.withQueue path (PartitionCount 10) $ \queue -> do


### PR DESCRIPTION
Support creating multiple consumers at once.
It avoids re-sending messages on emulator start.