### PR TITLE
Handle interrupts

### DIFF
--- a/build/Dockerfile.aarch64.linux
+++ b/build/Dockerfile.aarch64.linux
@@ -80,6 +80,6 @@ RUN cabal build \
     --ghc-options='-optl-lpq -optl-lssl -optl-lcrypto -optl-lpgcommon -optl-lpgport -optl-lzstd -optl-llz4 -optl-lxml2 -optl-lssl -optl-lcrypto -optl-lz -optl-lreadline -optl-lm' \
     emulator
 
-ENV PATH="/root/.local/bin:${PATH}"
+RUN ln -s $(cabal list-bin emulator) /usr/local/bin/emulator
 
 ENTRYPOINT ["emulator"]

--- a/emulator.cabal
+++ b/emulator.cabal
@@ -30,6 +30,7 @@ executable emulator
         , prettyprinter
         , prettyprinter-ansi-terminal
         , optparse-applicative
+        , unix
 
 library emulator-lib
     import: common

--- a/emulator.cabal
+++ b/emulator.cabal
@@ -30,7 +30,9 @@ executable emulator
         , prettyprinter
         , prettyprinter-ansi-terminal
         , optparse-applicative
-        , unix
+    if !os(windows)
+        build-depends:
+            unix
 
 library emulator-lib
     import: common

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE CPP #-}
 module Main where
 
 import Control.Applicative (optional)
@@ -47,10 +48,14 @@ main = do
       print _VERSION
   where
   handleInterrupts = do
+#if !defined(mingw32_HOST_OS)
     tid <- myThreadId
     let handler = Catch (throwTo tid UserInterrupt)
     void $ installHandler sigINT handler Nothing
     void $ installHandler sigTERM handler Nothing
+#else
+    return ()
+#endif
 
 
 defaultStatePath :: IO FilePath


### PR DESCRIPTION
`SIGTERM` wasn't being handled by default so now we explicitly handle `SIGINT` and `SIGTERM`.
As before, `SIGKILL` should not be handled.