### PR TITLE
Support PostgreSQL tests on Docker

### DIFF
--- a/emulator.cabal
+++ b/emulator.cabal
@@ -105,6 +105,7 @@ test-suite emulator-tests
         Test.OnDemand
         Test.Warden
         Test.Utils.OnDemand
+        Test.Utils.Docker
     type:    exitcode-stdio-1.0
     build-depends:
         base

--- a/tests/Test/Connector.hs
+++ b/tests/Test/Connector.hs
@@ -1,15 +1,15 @@
 {-# OPTIONS_GHC -Wno-x-partial #-}
 module Test.Connector
   ( testConnectors
+
   , PostgresCreds
   , withPostgreSQL
-  , withEventsTable
   , mkPostgreSQL
+  , Debugging(..)
+
   , Event(..)
   , Table(..)
-
-  , BytesRow(..)
-  , Debugging(..)
+  , withEventsTable
   ) where
 
 import Control.Concurrent (MVar, newMVar, modifyMVar)
@@ -545,7 +545,6 @@ withConnection creds act = do
     , P.connectPort = p_port creds
     }
   act conn
-
 
 -- | Creates a new table on every invocation.
 withPgTable :: P.Connection -> Schema -> (String -> IO a) -> IO a

--- a/tests/Test/Connector.hs
+++ b/tests/Test/Connector.hs
@@ -4,7 +4,6 @@ module Test.Connector
   , PostgresCreds
   , withPostgresSQL
   , withEventsTable
-  , withConnection
   , mkPostgreSQL
   , Event(..)
   , Table(..)
@@ -503,8 +502,11 @@ instance Table EventsTable where
         , ")"
         ]
 
-withEventsTable :: P.Connection -> (EventsTable -> IO a) -> IO a
-withEventsTable = withTable ()
+withEventsTable :: PostgresCreds -> (P.Connection -> EventsTable -> IO a) -> IO a
+withEventsTable creds f =
+  withConnection creds $ \conn ->
+  withTable () conn $ \table ->
+  f conn table
 
 {-# NOINLINE tableNumber #-}
 tableNumber :: MVar Int

--- a/tests/Test/Emulator.hs
+++ b/tests/Test/Emulator.hs
@@ -121,8 +121,7 @@ testEmulator p = describe "emulator" $ do
     withPostgresSource :: (([Event] -> IO ()) -> DataSource -> IO a) -> IO a
     withPostgresSource f =
       OnDemand.with p $ \creds ->
-      C.withConnection creds $ \conn ->
-      C.withEventsTable conn $ \table -> do
+      C.withEventsTable creds $ \conn table -> do
       let config = C.mkPostgreSQL creds table
           source = DataSource
             { s_id = Id "postgres_source"

--- a/tests/Test/Utils/Docker.hs
+++ b/tests/Test/Utils/Docker.hs
@@ -1,0 +1,96 @@
+module Test.Utils.Docker
+  ( DockerCommand(..)
+  , withDocker
+  ) where
+
+import Control.Concurrent (MVar, newMVar, modifyMVar)
+import Control.Exception (throwIO, ErrorCall(..))
+import System.Exit (ExitCode(..))
+import System.IO.Temp (withSystemTempFile)
+import System.IO
+  ( Handle
+  , IOMode(..)
+  , BufferMode(..)
+  , hClose
+  , hSetBuffering
+  , stdout
+  , withFile
+  )
+import System.Process
+  ( CreateProcess(..)
+  , StdStream(..)
+  , proc
+  , withCreateProcess
+  , waitForProcess
+  , createPipe
+  )
+import System.IO.Unsafe (unsafePerformIO)
+import Utils.Async (withAsyncThrow)
+
+data DockerCommand
+  = DockerRun
+    { run_image :: String
+    , run_args :: [String]
+    }
+
+{-# NOINLINE dockerImageNumber #-}
+dockerImageNumber :: MVar Int
+dockerImageNumber = unsafePerformIO (newMVar 0)
+
+-- | Run a command with a docker image running in the background.
+-- Automatically assigns a container name and removes the container
+-- on exit.
+--
+-- The handle provided contains both stdout and stderr
+withDocker :: String -> DockerCommand -> (Handle -> IO a) -> IO a
+withDocker tag cmd act =
+  withPipe $ \hread hwrite -> do
+  name <- mkName
+  let create = (proc "docker" (args name))
+        { std_out = UseHandle hwrite
+        , std_err = UseHandle hwrite
+        , create_group = True
+        }
+  withCreateProcess create $ \_ _ _ p ->
+    withAsyncThrow (wait name p) $
+    act hread
+  where
+  withPipe f = do
+    (hread, hwrite) <- createPipe
+    hSetBuffering hread LineBuffering
+    hSetBuffering hwrite LineBuffering
+    f hread hwrite
+
+  wait name p = do
+    exit <- waitForProcess p
+    throwIO $ ErrorCall $ case exit of
+      ExitSuccess ->  "unexpected successful termination of container " <> name
+      ExitFailure code ->
+        "docker failed with exit code" <> show code <> " for container " <> name
+
+  mkName = do
+    number <- modifyMVar dockerImageNumber $ \n -> return (n + 1, n)
+    return $ tag <> "_" <> show number
+
+  args :: String -> [String]
+  args name =
+    case cmd of
+      DockerRun img opts ->
+        [ "run"
+        , "--init" -- ensure SIGTERM from `withCreateProcess` kills the container
+        , "--rm"   -- remove container on exit
+        , "--name", name -- name this run
+        ] ++ opts ++ [img]
+
+  _withHandle name f = do
+    let debug = False -- set to true to print Docker output to sdtdout
+        mhandle =
+          if debug
+          then Just stdout
+          else Nothing
+    case mhandle of
+      Just handle -> f handle
+      Nothing -> withSystemTempFile (name <> "-output") (\path h0 -> do
+        hClose h0
+        withFile path ReadWriteMode f
+        )

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -5,7 +5,7 @@ import Test.Hspec (hspec, parallel)
 import Test.Config (testConfig)
 import Test.Emulator (testEmulator)
 import Test.Queue (testQueues)
-import Test.Connector (testConnectors, withPostgreSQLDocker)
+import Test.Connector (testConnectors, withPostgreSQLDocker, Debugging(..))
 import Test.OnDemand (testOnDemand)
 import Test.Warden (testWarden)
 import qualified Test.Utils.OnDemand as OnDemand
@@ -22,7 +22,7 @@ Example: match on test description
  -}
 main :: IO ()
 main =
-  OnDemand.withLazy withPostgreSQLDocker $ \pcreds ->
+  OnDemand.withLazy (withPostgreSQLDocker (Debugging False)) $ \pcreds ->
   hspec $ parallel $ do
     -- unit tests use the projector library
     testOnDemand

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -5,7 +5,7 @@ import Test.Hspec (hspec, parallel)
 import Test.Config (testConfig)
 import Test.Emulator (testEmulator)
 import Test.Queue (testQueues)
-import Test.Connector (testConnectors, withPostgreSQLDocker, Debugging(..))
+import Test.Connector (testConnectors, withPostgreSQL, Debugging(..))
 import Test.OnDemand (testOnDemand)
 import Test.Warden (testWarden)
 import qualified Test.Utils.OnDemand as OnDemand
@@ -22,7 +22,7 @@ Example: match on test description
  -}
 main :: IO ()
 main =
-  OnDemand.withLazy (withPostgreSQLDocker (Debugging False)) $ \pcreds ->
+  OnDemand.withLazy (withPostgreSQL (Debugging False)) $ \pcreds ->
   hspec $ parallel $ do
     -- unit tests use the projector library
     testOnDemand

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -5,7 +5,7 @@ import Test.Hspec (hspec, parallel)
 import Test.Config (testConfig)
 import Test.Emulator (testEmulator)
 import Test.Queue (testQueues)
-import Test.Connector (testConnectors, withPostgresSQL)
+import Test.Connector (testConnectors, withPostgreSQLDocker)
 import Test.OnDemand (testOnDemand)
 import Test.Warden (testWarden)
 import qualified Test.Utils.OnDemand as OnDemand
@@ -21,8 +21,8 @@ Example: match on test description
 
  -}
 main :: IO ()
-main = do
-  pcreds <- OnDemand.lazy withPostgresSQL
+main =
+  OnDemand.withLazy withPostgreSQLDocker $ \pcreds ->
   hspec $ parallel $ do
     -- unit tests use the projector library
     testOnDemand


### PR DESCRIPTION
Changing a debug flag allows us to see everything the container is printing in our stdout.
The dockerized process is guaranteed to be cleanly finished and the container will be removed upon exit.
The db's docker image gets spun up only once when needed in tests and its instance is shared in all its uses.