### PR TITLE
Add SQLServer config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A YAML configuration file should describe all sources and destinations to be use
 data_sources:
 
   # Connect to a PostgreSQL database
-  - id: my_postgres_source
+  - id: postgres_source
     description: Main events store
     type: postgres
     host: localhost
@@ -36,11 +36,29 @@ data_sources:
     partitioningColumn: aggregate_id
 
   # Connect to a MySQL database
-  - id: my_mysql_source
+  - id: postgres_source
     description: Main events store
     type: mysql
     host: localhost
     port: 5432
+    username: my_user
+    password: my_pass
+    database: my_db
+    table: events_table
+    columns:
+      - id
+      - aggregate_id
+      - sequence_number
+      - payload
+    autoIncrementingColumn: id
+    partitioningColumn: aggregate_id
+
+  # Connect to an SQLServer database
+  - id: sqlserver_source
+    description: Main events store
+    type: sqlserver
+    host: localhost
+    port: 1433
     username: my_user
     password: my_pass
     database: my_db
@@ -66,8 +84,9 @@ data_destinations:
     password: password123
 
     sources:
-      - my_mysql_source
-      - my_postgres_source
+      - postgres_source
+      - sqlserver_source
+      - file_source
 
   # Send data to a file. One entry per line.
   - id: file_destination
@@ -76,8 +95,9 @@ data_destinations:
     path: ./temp.file
 
     sources:
-      - my_mysql_source
-      - my_postgres_source
+      - postgres_source
+      - sqlserver_source
+      - file_source
 ```
 
 ## Running the program

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -38,6 +38,24 @@ data_sources:
     autoIncrementingColumn: id
     partitioningColumn: aggregate_id
 
+  # Connect to an SQLServer database
+  - id: sqlserver_source
+    description: Main events store
+    type: sqlserver
+    host: localhost
+    port: 1433
+    username: my_user
+    password: my_pass
+    database: my_db
+    table: events_table
+    columns:
+      - id
+      - aggregate_id
+      - sequence_number
+      - payload
+    autoIncrementingColumn: id
+    partitioningColumn: aggregate_id
+
 # Connections to your endpoint.
 # The Emulator will send data read from the databases to these endpoints.
 data_destinations:
@@ -51,8 +69,9 @@ data_destinations:
     password: password123
 
     sources:
-      - postgres source
-      - file source
+      - postgres_source
+      - sqlserver_source
+      - file_source
 
   # Send data to a file. One entry per line.
   - id: file_destination
@@ -62,4 +81,5 @@ data_destinations:
 
     sources:
       - postgres_source
+      - sqlserver_source
       - file_source

--- a/src/Ambar/Emulator/Config.hs
+++ b/src/Ambar/Emulator/Config.hs
@@ -27,6 +27,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Yaml as Yaml
 
+import Ambar.Emulator.Connector.MicrosoftSQLServer (SQLServer(..))
 import Ambar.Emulator.Connector.Postgres (PostgreSQL(..))
 import Ambar.Emulator.Connector.MySQL (MySQL(..))
 import Ambar.Emulator.Connector.File (FileConnector(..))
@@ -60,6 +61,7 @@ data Source
   = SourceFile FileConnector
   | SourcePostgreSQL PostgreSQL
   | SourceMySQL MySQL
+  | SourceSQLServer SQLServer
 
 data DataDestination = DataDestination
   { d_id :: Id DataDestination
@@ -104,6 +106,7 @@ instance FromJSON DataSource where
       case t of
         "postgres" -> parsePostgreSQL o
         "mysql" -> parseMySQL o
+        "sqlserver" -> parseSQLServer o
         "file" -> parseFile o
         _ -> fail $ unwords
           [ "Invalid data source type: '" <> t <> "'."
@@ -134,6 +137,18 @@ instance FromJSON DataSource where
       c_partitioningColumn <- o .: "partitioningColumn"
       c_incrementingColumn <- o .: "autoIncrementingColumn"
       return $ SourceMySQL MySQL{..}
+
+    parseSQLServer o = do
+      c_host <- o .: "host"
+      c_port <- o .: "port"
+      c_username <- o .: "username"
+      c_password <- o .: "password"
+      c_database <- o .: "database"
+      c_table <- o .: "table"
+      c_columns <- o .: "columns"
+      c_partitioningColumn <- o .: "partitioningColumn"
+      c_incrementingColumn <- o .: "autoIncrementingColumn"
+      return $ SourceSQLServer SQLServer{..}
 
     parseFile o = SourceFile . FileConnector <$> (o .: "path")
 

--- a/src/Ambar/Emulator/Projector.hs
+++ b/src/Ambar/Emulator/Projector.hs
@@ -26,6 +26,7 @@ import GHC.Generics (Generic)
 import Ambar.Emulator.Config (Id(..), DataDestination, DataSource(..), Source(..))
 import Ambar.Emulator.Queue.Topic (Topic, ReadError(..), PartitionCount(..))
 import qualified Ambar.Emulator.Queue.Topic as Topic
+import Ambar.Emulator.Connector.MicrosoftSQLServer (SQLServer(..))
 import Ambar.Emulator.Connector.Postgres (PostgreSQL(..))
 import Ambar.Emulator.Connector.MySQL (MySQL(..))
 import Ambar.Transport (Transport)
@@ -117,6 +118,12 @@ relevantFields source (Payload value) = renderPretty $
       fillSep $
         [ pretty field <> ":" <+> prettyJSON v
         | field <- [c_serialColumn, c_partitioningColumn]
+        , Just v <- [KeyMap.lookup (fromString $ Text.unpack field) o]
+        ]
+    SourceSQLServer SQLServer{..} ->
+      fillSep $
+        [ pretty field <> ":" <+> prettyJSON v
+        | field <- [c_incrementingColumn, c_partitioningColumn]
         , Just v <- [KeyMap.lookup (fromString $ Text.unpack field) o]
         ]
   where

--- a/tests/Test/Utils/SQL.hs
+++ b/tests/Test/Utils/SQL.hs
@@ -29,7 +29,7 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import System.IO.Unsafe (unsafePerformIO)
-import Test.Hspec (Spec, it, shouldBe)
+import Test.Hspec (Spec, it, shouldBe, sequential)
 import Test.Hspec.Expectations.Contrib (annotate)
 
 import Ambar.Emulator.Connector (partitioner, encoder, Connector(..))
@@ -81,7 +81,7 @@ testGenericSQL
   -> (db -> table -> connector)
   -> Config table
   -> Spec
-testGenericSQL od withConnection mkConfig conf = do
+testGenericSQL od withConnection mkConfig conf = sequential $ do
   -- checks that our tests can connect to postgres
   it "connects" $
     with (PartitionCount 1) $ \conn table _ _ -> do


### PR DESCRIPTION
You can now add SQLServer as a data source

```

  # Connect to an SQLServer database
  - id: sqlserver_source
    description: Main events store
    type: sqlserver
    host: localhost
    port: 1433
    username: my_user
    password: my_pass
    database: my_db
    table: events_table
    columns:
      - id
      - aggregate_id
      - sequence_number
      - payload
    autoIncrementingColumn: id
    partitioningColumn: aggregate_id
```