### PR TITLE
Support Polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ data_sources:
       - payload
     serialColumn: id
     partitioningColumn: aggregate_id
+    pollingInterval: 0.050
 
   # Connect to a MySQL database
   - id: mysql_source
@@ -52,6 +53,7 @@ data_sources:
       - payload
     autoIncrementingColumn: id
     partitioningColumn: aggregate_id
+    pollingInterval: 0.050
 
   # Connect to an SQLServer database
   - id: sqlserver_source
@@ -70,6 +72,7 @@ data_sources:
       - payload
     autoIncrementingColumn: id
     partitioningColumn: aggregate_id
+    pollingInterval: 0.050
 
   # Use a plain text file as a data source.
   # Each line must be a valid JSON object.
@@ -80,6 +83,7 @@ data_sources:
     path: ./path/to/source.file
     incrementingField: id
     partitioningField: aggregate_id
+    pollingInterval: 0.050
 
 # Connections to your endpoint.
 # The Emulator will send data read from the databases to these endpoints.

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -19,6 +19,7 @@ data_sources:
       - payload
     serialColumn: id
     partitioningColumn: aggregate_id
+    pollingInterval: 0.050
 
   # Connect to a MySQL database
   - id: mysql_source
@@ -37,6 +38,7 @@ data_sources:
       - payload
     autoIncrementingColumn: id
     partitioningColumn: aggregate_id
+    pollingInterval: 0.050
 
   # Connect to an SQLServer database
   - id: sqlserver_source
@@ -55,6 +57,7 @@ data_sources:
       - payload
     autoIncrementingColumn: id
     partitioningColumn: aggregate_id
+    pollingInterval: 0.050
 
   # Use a plain text file as a data source.
   # Each line must be a valid JSON object.
@@ -65,6 +68,7 @@ data_sources:
     path: ./path/to/source.file
     incrementingField: id
     partitioningField: aggregate_id
+    pollingInterval: 0.050
 
 # Connections to your endpoint.
 # The Emulator will send data read from the databases to these endpoints.

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -17,7 +17,9 @@ import System.Posix.Signals (installHandler, sigINT, sigTERM, Handler(Catch))
 
 import Ambar.Emulator (emulate)
 import Ambar.Emulator.Config (parseEnvConfigFile, EmulatorConfig(..))
+import Ambar.Emulator.Connector.Poll (PollingInterval(..))
 import Util.Logger (plainLogger, Severity(..), logInfo)
+import Util.Delay (fromDiffTime)
 
 
 _DEFAULT_PARTITIONS_PER_TOPIC :: Int
@@ -73,6 +75,7 @@ data Command
     , o_statePath :: Maybe FilePath
     , o_configPath :: FilePath
     , o_verbose :: Bool
+    , o_overridePollingInterval :: Maybe PollingInterval
     }
   | CmdVersion
 
@@ -103,6 +106,12 @@ cliOptions = O.info (O.simpleVersioner _VERSION <*> O.helper <*> parser) $ mconc
           [ O.long "partitions-per-topic"
           , O.metavar "INT"
           , O.help "How many partitions should newly created topics have."
+          ]
+      o_overridePollingInterval <-
+        fmap (fmap $ PollingInterval . fromDiffTime . realToFrac @Double) $ optional $ O.option O.auto $ mconcat
+          [ O.long "override-polling-interval"
+          , O.metavar "SECONDS"
+          , O.help "Override the polling interval for all polled data sources."
           ]
       o_statePath <- optional $ O.strOption $ mconcat
           [ O.long "data-path"

--- a/tests/Test/Connector/MicrosoftSQLServer.hs
+++ b/tests/Test/Connector/MicrosoftSQLServer.hs
@@ -22,6 +22,7 @@ import Test.Hspec
 
 import qualified Ambar.Emulator.Queue.Topic as Topic
 import Ambar.Emulator.Queue.Topic (Topic, PartitionCount(..))
+import Ambar.Emulator.Connector.Poll (PollingInterval(..))
 import Ambar.Emulator.Connector.MicrosoftSQLServer (SQLServer(..))
 import Ambar.Record (Bytes(..))
 import Database.SQLServer as S
@@ -41,7 +42,7 @@ import Test.Util.SQL
   , group
   )
 
-import Util.Delay (deadline, seconds)
+import Util.Delay (deadline, seconds, millis)
 
 testMicrosoftSQLServer :: OnDemand MicrosoftSQLServerCreds -> Spec
 testMicrosoftSQLServer od = do
@@ -154,6 +155,7 @@ mkConnector ConnectionInfo{..} table = SQLServer
   , c_columns = tableCols table
   , c_partitioningColumn = "aggregate_id"
   , c_incrementingColumn = "id"
+  , c_pollingInterval = PollingInterval (millis 10)
   }
 
 instance Table (EventsTable SQLServer) where

--- a/tests/Test/Connector/MySQL.hs
+++ b/tests/Test/Connector/MySQL.hs
@@ -27,6 +27,7 @@ import Test.Hspec
   )
 
 import Ambar.Emulator.Connector as Connector
+import Ambar.Emulator.Connector.Poll (PollingInterval(..))
 import Ambar.Emulator.Connector.MySQL (MySQL(..))
 import Database.MySQL
    ( ConnectionInfo(..)
@@ -48,7 +49,7 @@ import qualified Ambar.Emulator.Queue.Topic as Topic
 import Ambar.Emulator.Queue.Topic (PartitionCount(..))
 import Ambar.Record (Bytes(..))
 
-import Util.Delay (deadline, seconds)
+import Util.Delay (deadline, seconds, millis)
 import Util.OnDemand (OnDemand)
 import Test.Util.SQL hiding (Connection)
 import qualified Test.Util.SQL as TS
@@ -213,6 +214,7 @@ mkMySQL ConnectionInfo{..} table = MySQL
   , c_columns = tableCols table
   , c_partitioningColumn = "aggregate_id"
   , c_incrementingColumn = "id"
+  , c_pollingInterval = PollingInterval (millis 10)
   }
 
 -- | Binary data saved in MySQL.

--- a/tests/Test/Connector/PostgreSQL.hs
+++ b/tests/Test/Connector/PostgreSQL.hs
@@ -39,6 +39,7 @@ import System.Process (readProcessWithExitCode)
 
 import qualified Ambar.Emulator.Connector as Connector
 import Ambar.Emulator.Connector.Postgres (PostgreSQL(..))
+import Ambar.Emulator.Connector.Poll (PollingInterval(..))
 import Ambar.Emulator.Queue.Topic (Topic, PartitionCount(..))
 import qualified Ambar.Emulator.Queue.Topic as Topic
 import Ambar.Record (Bytes(..))
@@ -47,7 +48,7 @@ import Util.OnDemand (OnDemand)
 import Test.Util.SQL
 import qualified Util.OnDemand as OnDemand
 
-import Util.Delay (deadline, seconds, delay)
+import Util.Delay (deadline, seconds, delay, millis)
 
 testPostgreSQL :: OnDemand PostgresCreds -> Spec
 testPostgreSQL p = do
@@ -260,6 +261,7 @@ mkPostgreSQL PostgresCreds{..} table = PostgreSQL
   , c_columns = tableCols table
   , c_partitioningColumn = "aggregate_id"
   , c_serialColumn = "id"
+  , c_pollingInterval = PollingInterval (millis 10)
   }
 
 data PostgresCreds = PostgresCreds


### PR DESCRIPTION
Set how often you want data sources to be polled.

Can be set per data source in the config (optional), or in the command line with `--override-polling-interval`.