### PR TITLE
Batch Postgres boundary queries to prevent excessive query size

### DIFF
--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -1,45 +1,45 @@
 module Ambar.Emulator.Connector.Postgres
-  ( PostgreSQL(..)
-  , PostgreSQLState(..)
-  ) where
+  ( PostgreSQL (..),
+    PostgreSQLState (..),
+  )
+where
 
+import Ambar.Emulator.Connector qualified as C
+import Ambar.Emulator.Connector.Poll (Boundaries (..), BoundaryTracker, EntryId (..), PollingInterval, Stream)
+import Ambar.Emulator.Connector.Poll qualified as Poll
+import Ambar.Emulator.Queue.Topic (Producer, hashPartitioner)
+import Ambar.Record (Bytes (..), Record (..), TimeStamp (..), Value (..))
+import Ambar.Record.Encoding qualified as Encoding
 import Control.Concurrent.STM (STM, TVar, newTVarIO, readTVar)
-import Control.Exception (bracket, throwIO, ErrorCall(..))
+import Control.Exception (ErrorCall (..), bracket, throwIO)
 import Control.Monad (foldM)
 import Data.Aeson (FromJSON, ToJSON)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as LB
-import Data.Default (Default(..))
+import Data.ByteString.Lazy qualified as LB
+import Data.Default (Default (..))
 import Data.List ((\\))
 import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
-import qualified Data.Map.Strict as Map
 import Data.String (fromString)
-import Data.Time.LocalTime (localTimeToUTC, utc)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text (decodeUtf8)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text (decodeUtf8)
+import Data.Time.LocalTime (localTimeToUTC, utc)
 import Data.Void (Void)
 import Data.Word (Word16)
-import qualified Database.PostgreSQL.Simple as P
-import qualified Database.PostgreSQL.Simple.Transaction as P
-import qualified Database.PostgreSQL.Simple.FromField as P
-import qualified Database.PostgreSQL.Simple.FromRow as P
+import Database.PostgreSQL.Simple qualified as P
+import Database.PostgreSQL.Simple.FromField qualified as P
+import Database.PostgreSQL.Simple.FromRow qualified as P
+import Database.PostgreSQL.Simple.Transaction qualified as P
 import GHC.Generics (Generic)
-import Util.Prettyprinter (renderPretty, sepBy, commaSeparated, prettyJSON)
 import Prettyprinter (pretty, (<+>))
-import qualified Prettyprinter as Pretty
-
-import qualified Ambar.Emulator.Connector.Poll as Poll
-import qualified Ambar.Emulator.Connector as C
-import Ambar.Emulator.Connector.Poll (BoundaryTracker, Boundaries(..), EntryId(..), Stream, PollingInterval)
-import Ambar.Emulator.Queue.Topic (Producer, hashPartitioner)
-import Ambar.Record (Record(..), Value(..), Bytes(..), TimeStamp(..))
-import qualified Ambar.Record.Encoding as Encoding
+import Prettyprinter qualified as Pretty
 import Util.Async (withAsyncThrow)
 import Util.Delay (Duration, millis, seconds)
 import Util.Logger (SimpleLogger, logDebug, logInfo)
+import Util.Prettyprinter (commaSeparated, prettyJSON, renderPretty, sepBy)
 
 _POLLING_INTERVAL :: Duration
 _POLLING_INTERVAL = millis 50
@@ -50,18 +50,20 @@ _MAX_TRANSACTION_TIME = seconds 120
 _MAX_BOUNDARY_BATCH_SIZE :: Int
 _MAX_BOUNDARY_BATCH_SIZE = 500
 
+_USE_FIX :: Bool
+_USE_FIX = True
 
 data PostgreSQL = PostgreSQL
-  { c_host :: Text
-  , c_port :: Word16
-  , c_username :: Text
-  , c_password :: Text
-  , c_database :: Text
-  , c_table :: Text
-  , c_columns :: [Text]
-  , c_partitioningColumn :: Text
-  , c_serialColumn :: Text
-  , c_pollingInterval :: PollingInterval
+  { c_host :: Text,
+    c_port :: Word16,
+    c_username :: Text,
+    c_password :: Text,
+    c_database :: Text,
+    c_table :: Text,
+    c_columns :: [Text],
+    c_partitioningColumn :: Text,
+    c_serialColumn :: Text,
+    c_pollingInterval :: PollingInterval
   }
 
 instance C.Connector PostgreSQL where
@@ -70,14 +72,14 @@ instance C.Connector PostgreSQL where
 
   partitioner = hashPartitioner partitioningValue
 
-  -- | A rows gets saved in the database as a JSON object with
+  -- \| A rows gets saved in the database as a JSON object with
   -- the columns specified in the config file as keys.
   encoder = LB.toStrict . Aeson.encode . Encoding.encode @Aeson.Value
 
   connect = connect
 
-newtype TableSchema = TableSchema { unTableSchema :: Map Text PgType }
-  deriving Show
+newtype TableSchema = TableSchema {unTableSchema :: Map Text PgType}
+  deriving (Show)
 
 -- | Supported PostgreSQL types
 data PgType
@@ -117,132 +119,211 @@ newtype PostgreSQLState = PostgreSQLState BoundaryTracker
   deriving newtype (Default)
   deriving anyclass (FromJSON, ToJSON)
 
-connect
-  :: PostgreSQL
-  -> SimpleLogger
-  -> PostgreSQLState
-  -> Producer Record
-  -> (STM PostgreSQLState -> IO a)
-  -> IO a
-connect config@PostgreSQL{..} logger (PostgreSQLState tracker) producer f =
-   bracket open P.close $ \conn -> do
-   schema <- fetchSchema c_table conn
-   validate config schema
-   trackerVar <- newTVarIO tracker
-   let readState = PostgreSQLState <$> readTVar trackerVar
-   withAsyncThrow (consume conn c_pollingInterval schema trackerVar) (f readState)
-   where
-   open = P.connect P.ConnectInfo
-      { P.connectHost = Text.unpack c_host
-      , P.connectPort = c_port
-      , P.connectUser = Text.unpack c_username
-      , P.connectPassword = Text.unpack c_password
-      , P.connectDatabase = Text.unpack c_database
-      }
-
-   consume
-      :: P.Connection
-      -> PollingInterval
-      -> TableSchema
-      -> TVar BoundaryTracker
-      -> IO Void
-   consume conn interval schema trackerVar = Poll.connect trackerVar pc
-     where
-     pc = Poll.PollingConnector
-        { Poll.c_getId = entryId
-        , Poll.c_poll = run
-        , Poll.c_pollingInterval = interval
-        , Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME
-        , Poll.c_producer = producer
-        }
-
-     parser = mkParser (columns config) schema
-
-     opts = P.FoldOptions
-       { P.fetchQuantity = P.Automatic
-       , P.transactionMode = P.TransactionMode
-          { P.isolationLevel = P.ReadCommitted
-          , P.readWriteMode = P.ReadOnly
+connect ::
+  PostgreSQL ->
+  SimpleLogger ->
+  PostgreSQLState ->
+  Producer Record ->
+  (STM PostgreSQLState -> IO a) ->
+  IO a
+connect config@PostgreSQL {..} logger (PostgreSQLState tracker) producer f =
+  bracket open P.close $ \conn -> do
+    schema <- fetchSchema c_table conn
+    validate config schema
+    trackerVar <- newTVarIO tracker
+    let readState = PostgreSQLState <$> readTVar trackerVar
+    withAsyncThrow (consume conn c_pollingInterval schema trackerVar) (f readState)
+  where
+    open =
+      P.connect
+        P.ConnectInfo
+          { P.connectHost = Text.unpack c_host,
+            P.connectPort = c_port,
+            P.connectUser = Text.unpack c_username,
+            P.connectPassword = Text.unpack c_password,
+            P.connectDatabase = Text.unpack c_database
           }
-       }
 
-     run :: Boundaries -> Stream Record
-     run (Boundaries bs) acc0 emit = do
-       let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
-       (acc, mLastUpper) <- foldM
-         (\(acc, mLower) batch -> do
-           let upper = snd (lastElem batch)
-           acc' <- runBatch mLower (Just upper) batch acc
-           return (acc', Just upper)
-         ) (acc0, Nothing) batches
-       runBatch mLastUpper Nothing [] acc
-       where
-       runBatch mLower mUpper batchBs acc = do
-         logDebug logger batchQuery
-         (acc', count) <- P.foldWithOptionsAndParser opts parser conn (fromString batchQuery) () (acc, 0) $
-           \(a, !count) record -> do
-             logResult record
-             a' <- emit a record
-             return (a', succ count)
-         logDebug logger $ "results: " <> show @Int count
-         return acc'
-         where
-         batchQuery = fromString $ Text.unpack $ renderPretty $ Pretty.fillSep
-            [ "SELECT" , commaSeparated $ map pretty $ columns config
-            , "FROM" , pretty c_table
-            , if null allConstraints then "" else "WHERE" <+> sepBy "AND" allConstraints
-            , "ORDER BY" , pretty c_serialColumn
-            ]
+    consume ::
+      P.Connection ->
+      PollingInterval ->
+      TableSchema ->
+      TVar BoundaryTracker ->
+      IO Void
+    consume conn interval schema trackerVar = Poll.connect trackerVar pc
+      where
+        pc =
+          Poll.PollingConnector
+            { Poll.c_getId = entryId,
+              Poll.c_poll = run,
+              Poll.c_pollingInterval = interval,
+              Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME,
+              Poll.c_producer = producer
+            }
 
-         allConstraints = lowerBound ++ upperBound ++ exclusions
+        parser = mkParser (columns config) schema
 
-         lowerBound = case mLower of
-           Nothing -> []
-           Just (EntryId low) ->
-             [Pretty.fillSep [pretty low, "<", pretty c_serialColumn]]
+        opts =
+          P.FoldOptions
+            { P.fetchQuantity = P.Automatic,
+              P.transactionMode =
+                P.TransactionMode
+                  { P.isolationLevel = P.ReadCommitted,
+                    P.readWriteMode = P.ReadOnly
+                  }
+            }
 
-         upperBound = case mUpper of
-           Nothing -> []
-           Just (EntryId high) ->
-             [Pretty.fillSep [pretty c_serialColumn, "<=", pretty high]]
+        run :: Boundaries -> Stream Record
+        run (Boundaries bs) acc0 emit =
+          if _USE_FIX
+            then run_new (Boundaries bs) acc0 emit
+            else run_old (Boundaries bs) acc0 emit
 
-         exclusions =
-            [ Pretty.fillSep
-               [ "("
-               , pretty c_serialColumn, "<", pretty low
-               , "OR"
-               ,  pretty high, "<", pretty c_serialColumn
-               , ")"]
-            | (EntryId low, EntryId high) <- batchBs
-            ]
+        run_old :: Boundaries -> Stream Record
+        run_old (Boundaries bs) acc0 emit = do
+          logDebug logger query
+          (acc, count) <- P.foldWithOptionsAndParser opts parser conn (fromString query) () (acc0, 0) $
+            \(acc, !count) record -> do
+              logResult record
+              acc' <- emit acc record
+              return (acc', succ count)
+          logDebug logger $ "results: " <> show @Int count
+          return acc
+          where
+            query =
+              fromString $
+                Text.unpack $
+                  renderPretty $
+                    Pretty.fillSep
+                      [ "SELECT",
+                        commaSeparated $ map pretty $ columns config,
+                        "FROM",
+                        pretty c_table,
+                        if null bs then "" else "WHERE" <> constraints,
+                        "ORDER BY",
+                        pretty c_serialColumn
+                      ]
 
-       logResult row =
-        logInfo logger $ renderPretty $
-          "ingested." <+> commaSeparated
-            [ "serial_value:" <+> prettyJSON (serialValue row)
-            , "partitioning_value:" <+> prettyJSON (partitioningValue row)
-            ]
+            constraints =
+              sepBy
+                "AND"
+                [ Pretty.fillSep
+                    [ "(",
+                      pretty c_serialColumn,
+                      "<",
+                      pretty low,
+                      "OR",
+                      pretty high,
+                      "<",
+                      pretty c_serialColumn,
+                      ")"
+                    ]
+                | (EntryId low, EntryId high) <- bs
+                ]
 
-       chunksOf :: Int -> [a] -> [[a]]
-       chunksOf _ [] = []
-       chunksOf n xs = let (chunk, rest) = splitAt n xs in chunk : chunksOf n rest
+            logResult row =
+              logInfo logger $
+                renderPretty $
+                  "ingested."
+                    <+> commaSeparated
+                      [ "serial_value:" <+> prettyJSON (serialValue row),
+                        "partitioning_value:" <+> prettyJSON (partitioningValue row)
+                      ]
 
-       lastElem :: [a] -> a
-       lastElem [] = error "lastElem: empty list"
-       lastElem [x] = x
-       lastElem (_:xs) = lastElem xs
+        run_new :: Boundaries -> Stream Record
+        run_new (Boundaries bs) acc0 emit = do
+          let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
+          (acc, mLastUpper) <-
+            foldM
+              ( \(acc, mLower) batch -> do
+                  let upper = snd (lastElem batch)
+                  acc' <- runBatch mLower (Just upper) batch acc
+                  return (acc', Just upper)
+              )
+              (acc0, Nothing)
+              batches
+          runBatch mLastUpper Nothing [] acc
+          where
+            runBatch mLower mUpper batchBs acc = do
+              logDebug logger batchQuery
+              (acc', count) <- P.foldWithOptionsAndParser opts parser conn (fromString batchQuery) () (acc, 0) $
+                \(a, !count) record -> do
+                  logResult record
+                  a' <- emit a record
+                  return (a', succ count)
+              logDebug logger $ "results: " <> show @Int count
+              return acc'
+              where
+                batchQuery =
+                  fromString $
+                    Text.unpack $
+                      renderPretty $
+                        Pretty.fillSep
+                          [ "SELECT",
+                            commaSeparated $ map pretty $ columns config,
+                            "FROM",
+                            pretty c_table,
+                            if null allConstraints then "" else "WHERE" <+> sepBy "AND" allConstraints,
+                            "ORDER BY",
+                            pretty c_serialColumn
+                          ]
+
+                allConstraints = lowerBound ++ upperBound ++ exclusions
+
+                lowerBound = case mLower of
+                  Nothing -> []
+                  Just (EntryId low) ->
+                    [Pretty.fillSep [pretty low, "<", pretty c_serialColumn]]
+
+                upperBound = case mUpper of
+                  Nothing -> []
+                  Just (EntryId high) ->
+                    [Pretty.fillSep [pretty c_serialColumn, "<=", pretty high]]
+
+                exclusions =
+                  [ Pretty.fillSep
+                      [ "(",
+                        pretty c_serialColumn,
+                        "<",
+                        pretty low,
+                        "OR",
+                        pretty high,
+                        "<",
+                        pretty c_serialColumn,
+                        ")"
+                      ]
+                  | (EntryId low, EntryId high) <- batchBs
+                  ]
+
+            logResult row =
+              logInfo logger $
+                renderPretty $
+                  "ingested."
+                    <+> commaSeparated
+                      [ "serial_value:" <+> prettyJSON (serialValue row),
+                        "partitioning_value:" <+> prettyJSON (partitioningValue row)
+                      ]
+
+            chunksOf :: Int -> [a] -> [[a]]
+            chunksOf _ [] = []
+            chunksOf n xs = let (chunk, rest) = splitAt n xs in chunk : chunksOf n rest
+
+            lastElem :: [a] -> a
+            lastElem [] = error "lastElem: empty list"
+            lastElem [x] = x
+            lastElem (_ : xs) = lastElem xs
 
 -- | Columns in the order they will be queried.
 columns :: PostgreSQL -> [Text]
-columns PostgreSQL{..} =
-  [c_serialColumn, c_partitioningColumn] <>
-    ((c_columns \\ [c_serialColumn]) \\ [c_partitioningColumn])
+columns PostgreSQL {..} =
+  [c_serialColumn, c_partitioningColumn]
+    <> ((c_columns \\ [c_serialColumn]) \\ [c_partitioningColumn])
 
 serialValue :: Record -> Value
 serialValue (Record row) =
   case row of
     [] -> error "serialValue: empty row"
-    (_,x):_ -> x
+    (_, x) : _ -> x
 
 partitioningValue :: Record -> Value
 partitioningValue (Record row) = snd $ row !! 1
@@ -250,88 +331,86 @@ partitioningValue (Record row) = snd $ row !! 1
 mkParser :: [Text] -> TableSchema -> P.RowParser Record
 mkParser cols (TableSchema schema) = Record . zip cols <$> traverse (parser . getType) cols
   where
-  getType col = schema Map.! col
+    getType col = schema Map.! col
 
-  parser :: PgType -> P.RowParser Value
-  parser ty = fmap (fromMaybe Null) $ case ty of
-    PgInt8 -> fmap Int <$> P.field
-    PgInt2 -> fmap Int <$> P.field
-    PgInt4 -> fmap Int <$> P.field
-    PgFloat4 -> fmap Real <$> P.field
-    PgFloat8 -> fmap Real <$> P.field
-    PgBool -> fmap Boolean <$> P.field
-    PgJson -> do
-      -- this JSON type is untyped and therefore is conveyed as string
-      val <- P.field @Aeson.Value
-      let txt = Text.decodeUtf8 $ LB.toStrict $ Aeson.encode val
-      return (Just $ String txt)
-    PgBytea -> fmap (Binary . Bytes . P.fromBinary) <$> P.field
-    PgTimestamp -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStamp)
-    PgTimestamptz -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStampTZ)
-    PgText -> fmap String <$> P.field
+    parser :: PgType -> P.RowParser Value
+    parser ty = fmap (fromMaybe Null) $ case ty of
+      PgInt8 -> fmap Int <$> P.field
+      PgInt2 -> fmap Int <$> P.field
+      PgInt4 -> fmap Int <$> P.field
+      PgFloat4 -> fmap Real <$> P.field
+      PgFloat8 -> fmap Real <$> P.field
+      PgBool -> fmap Boolean <$> P.field
+      PgJson -> do
+        -- this JSON type is untyped and therefore is conveyed as string
+        val <- P.field @Aeson.Value
+        let txt = Text.decodeUtf8 $ LB.toStrict $ Aeson.encode val
+        return (Just $ String txt)
+      PgBytea -> fmap (Binary . Bytes . P.fromBinary) <$> P.field
+      PgTimestamp -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStamp)
+      PgTimestamptz -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStampTZ)
+      PgText -> fmap String <$> P.field
 
 parserTimeStampTZ :: P.FieldParser TimeStamp
 parserTimeStampTZ = parser
   where
-  parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
-  parser field mbs =
-    case mbs of
-      Nothing -> P.returnError P.UnexpectedNull field ""
-      Just bs -> do
-        let txt = Text.decodeUtf8 bs
-        utcTime <- P.fromField field mbs
-        return $ TimeStamp txt utcTime
+    parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
+    parser field mbs =
+      case mbs of
+        Nothing -> P.returnError P.UnexpectedNull field ""
+        Just bs -> do
+          let txt = Text.decodeUtf8 bs
+          utcTime <- P.fromField field mbs
+          return $ TimeStamp txt utcTime
 
 parserTimeStamp :: P.FieldParser TimeStamp
 parserTimeStamp = parser
   where
-  parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
-  parser field mbs =
-    case mbs of
-      Nothing -> P.returnError P.UnexpectedNull field ""
-      Just bs -> do
-        let txt = Text.decodeUtf8 bs
-        localTime <- P.fromField field mbs
-        return $ TimeStamp txt $ Just $ localTimeToUTC utc localTime
+    parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
+    parser field mbs =
+      case mbs of
+        Nothing -> P.returnError P.UnexpectedNull field ""
+        Just bs -> do
+          let txt = Text.decodeUtf8 bs
+          localTime <- P.fromField field mbs
+          return $ TimeStamp txt $ Just $ localTimeToUTC utc localTime
 
 entryId :: Record -> EntryId
 entryId record = case serialValue record of
-   Int n -> EntryId $ fromIntegral n
-   val -> error "Invalid serial column value:" (show val)
+  Int n -> EntryId $ fromIntegral n
+  val -> error "Invalid serial column value:" (show val)
 
 validate :: PostgreSQL -> TableSchema -> IO ()
 validate config (TableSchema schema) = do
   missingCol
   invalidSerial
   where
-  missing = filter (not . (`Map.member` schema)) (columns config)
-  missingCol =
-    case missing of
-      [] -> return ()
-      xs -> throwIO $ ErrorCall $ "Missing columns in target table: " <> Text.unpack (Text.unwords xs)
+    missing = filter (not . (`Map.member` schema)) (columns config)
+    missingCol =
+      case missing of
+        [] -> return ()
+        xs -> throwIO $ ErrorCall $ "Missing columns in target table: " <> Text.unpack (Text.unwords xs)
 
-  invalidSerial =
-    if serialTy `elem` allowedSerialTypes
-    then return ()
-    else throwIO $ ErrorCall $ "Invalid serial column type: " <> show serialTy
-  serialTy = schema Map.! c_serialColumn config
-  allowedSerialTypes = [PgInt8, PgInt2, PgInt4]
+    invalidSerial =
+      if serialTy `elem` allowedSerialTypes
+        then return ()
+        else throwIO $ ErrorCall $ "Invalid serial column type: " <> show serialTy
+    serialTy = schema Map.! c_serialColumn config
+    allowedSerialTypes = [PgInt8, PgInt2, PgInt4]
 
 fetchSchema :: Text -> P.Connection -> IO TableSchema
 fetchSchema table conn = do
-   cols <- P.query conn query [table]
-   return $ TableSchema $ Map.fromList cols
-   where
-   -- In PostgreSQL internals 'columns' are called 'attributes' for hysterical raisins.
-   -- oid is the table identifier in the pg_class table.
-   query = fromString $ unwords
-      [ "SELECT a.attname, t.typname"
-      , "  FROM pg_class c"
-      , "  JOIN pg_attribute a ON relname = ? AND c.oid = a.attrelid AND a.attnum > 0"
-      , "  JOIN pg_type t ON t.oid = a.atttypid"
-      , "  ORDER BY a.attnum ASC;"
-      ]
-
-
-
-
+  cols <- P.query conn query [table]
+  return $ TableSchema $ Map.fromList cols
+  where
+    -- In PostgreSQL internals 'columns' are called 'attributes' for hysterical raisins.
+    -- oid is the table identifier in the pg_class table.
+    query =
+      fromString $
+        unwords
+          [ "SELECT a.attname, t.typname",
+            "  FROM pg_class c",
+            "  JOIN pg_attribute a ON relname = ? AND c.oid = a.attrelid AND a.attnum > 0",
+            "  JOIN pg_type t ON t.oid = a.atttypid",
+            "  ORDER BY a.attnum ASC;"
+          ]

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -14,7 +14,7 @@ import Data.Default (Default(..))
 import Data.List ((\\))
 import Data.List.Extra (chunksOf)
 import Data.Map.Strict (Map)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe)
 import qualified Data.Map.Strict as Map
 import Data.String (fromString)
 import Data.Time.LocalTime (localTimeToUTC, utc)
@@ -162,18 +162,18 @@ connect config@PostgreSQL{..} logger (PostgreSQLState tracker) producer f =
      run (Boundaries bs) acc0 emit =
        P.withTransactionMode txMode conn $ do
          let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
-         case batches of
+             highest = fmap snd . listToMaybe . reverse
+         case reverse batches of
            [] ->
              runBatch Nothing Nothing [] acc0
-           _ -> do
-             let initBatches = init batches
-                 lastBatch = last batches
+           (lastBatch : restReversed) -> do
+             let initBatches = reverse restReversed
              (acc, mLastUpper) <-
                foldM
                  (\(acc, mLower) batch -> do
-                     let upper = snd (last batch)
-                     acc' <- runBatch mLower (Just upper) batch acc
-                     return (acc', Just upper)
+                     let mUpper = highest batch
+                     acc' <- runBatch mLower mUpper batch acc
+                     return (acc', mUpper)
                  )
                  (acc0, Nothing)
                  initBatches
@@ -187,15 +187,14 @@ connect config@PostgreSQL{..} logger (PostgreSQLState tracker) producer f =
 
        runBatch mLower mUpper batchBs acc = do
          logDebug logger batchQuery
-         rows <- P.queryWith_ parser conn (fromString batchQuery)
-         logDebug logger $ "results: " <> show (length rows)
-         foldM
-           (\a record -> do
+         (acc', count) <- P.foldWith_ parser conn (fromString batchQuery) (acc, 0 :: Int)
+           (\(a, n) record -> do
                logResult record
-               emit a record
+               a' <- emit a record
+               return (a', n + 1)
            )
-           acc
-           rows
+         logDebug logger $ "results: " <> show count
+         return acc'
          where
          batchQuery = fromString $ Text.unpack $ renderPretty $ Pretty.fillSep
             [ "SELECT" , commaSeparated $ map pretty $ columns config

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -19,6 +19,7 @@ import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as LB
 import Data.Default (Default (..))
 import Data.List ((\\))
+import Data.List.Extra (chunksOf)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -50,9 +51,6 @@ _MAX_TRANSACTION_TIME = seconds 120
 _MAX_BOUNDARY_BATCH_SIZE :: Int
 _MAX_BOUNDARY_BATCH_SIZE = 500
 
-_USE_FIX :: Bool
-_USE_FIX = True
-
 data PostgreSQL = PostgreSQL
   { c_host :: Text,
     c_port :: Word16,
@@ -72,7 +70,7 @@ instance C.Connector PostgreSQL where
 
   partitioner = hashPartitioner partitioningValue
 
-  -- \| A rows gets saved in the database as a JSON object with
+  -- | A rows gets saved in the database as a JSON object with
   -- the columns specified in the config file as keys.
   encoder = LB.toStrict . Aeson.encode . Encoding.encode @Aeson.Value
 
@@ -163,96 +161,45 @@ connect config@PostgreSQL {..} logger (PostgreSQLState tracker) producer f =
 
         parser = mkParser (columns config) schema
 
-        opts =
-          P.FoldOptions
-            { P.fetchQuantity = P.Automatic,
-              P.transactionMode =
-                P.TransactionMode
-                  { P.isolationLevel = P.ReadCommitted,
-                    P.readWriteMode = P.ReadOnly
-                  }
-            }
-
         run :: Boundaries -> Stream Record
         run (Boundaries bs) acc0 emit =
-          if _USE_FIX
-            then run_new (Boundaries bs) acc0 emit
-            else run_old (Boundaries bs) acc0 emit
-
-        run_old :: Boundaries -> Stream Record
-        run_old (Boundaries bs) acc0 emit = do
-          logDebug logger query
-          (acc, count) <- P.foldWithOptionsAndParser opts parser conn (fromString query) () (acc0, 0) $
-            \(acc, !count) record -> do
-              logResult record
-              acc' <- emit acc record
-              return (acc', succ count)
-          logDebug logger $ "results: " <> show @Int count
-          return acc
+          P.withTransactionMode txMode conn $ do
+            let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
+            case batches of
+              [] ->
+                runBatch Nothing Nothing [] acc0
+              _ -> do
+                let initBatches = init batches
+                    lastBatch = last batches
+                (acc, mLastUpper) <-
+                  foldM
+                    ( \(acc, mLower) batch -> do
+                        let upper = snd (last batch)
+                        acc' <- runBatch mLower (Just upper) batch acc
+                        return (acc', Just upper)
+                    )
+                    (acc0, Nothing)
+                    initBatches
+                -- last batch has no upper bound
+                runBatch mLastUpper Nothing lastBatch acc
           where
-            query =
-              fromString $
-                Text.unpack $
-                  renderPretty $
-                    Pretty.fillSep
-                      [ "SELECT",
-                        commaSeparated $ map pretty $ columns config,
-                        "FROM",
-                        pretty c_table,
-                        if null bs then "" else "WHERE" <> constraints,
-                        "ORDER BY",
-                        pretty c_serialColumn
-                      ]
+            txMode =
+              P.TransactionMode
+                { P.isolationLevel = P.ReadCommitted,
+                  P.readWriteMode = P.ReadOnly
+                }
 
-            constraints =
-              sepBy
-                "AND"
-                [ Pretty.fillSep
-                    [ "(",
-                      pretty c_serialColumn,
-                      "<",
-                      pretty low,
-                      "OR",
-                      pretty high,
-                      "<",
-                      pretty c_serialColumn,
-                      ")"
-                    ]
-                | (EntryId low, EntryId high) <- bs
-                ]
-
-            logResult row =
-              logInfo logger $
-                renderPretty $
-                  "ingested."
-                    <+> commaSeparated
-                      [ "serial_value:" <+> prettyJSON (serialValue row),
-                        "partitioning_value:" <+> prettyJSON (partitioningValue row)
-                      ]
-
-        run_new :: Boundaries -> Stream Record
-        run_new (Boundaries bs) acc0 emit = do
-          let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
-          (acc, mLastUpper) <-
-            foldM
-              ( \(acc, mLower) batch -> do
-                  let upper = snd (lastElem batch)
-                  acc' <- runBatch mLower (Just upper) batch acc
-                  return (acc', Just upper)
-              )
-              (acc0, Nothing)
-              batches
-          runBatch mLastUpper Nothing [] acc
-          where
             runBatch mLower mUpper batchBs acc = do
               logDebug logger batchQuery
-              (acc', count) <- P.foldWithOptionsAndParser opts parser conn (fromString batchQuery) () (acc, 0) $
-                \(a, !count) record -> do
-                  logResult record
-                  a' <- emit a record
-                  return (a', succ count)
-              logDebug logger $ "results: " <> show @Int count
-              return acc'
+              rows <- P.queryWith_ parser conn (fromString batchQuery)
+              logDebug logger $ "results: " <> show (length rows)
+              foldM
+                ( \a record -> do
+                    logResult record
+                    emit a record
+                )
+                acc
+                rows
               where
                 batchQuery =
                   fromString $
@@ -303,15 +250,6 @@ connect config@PostgreSQL {..} logger (PostgreSQLState tracker) producer f =
                       [ "serial_value:" <+> prettyJSON (serialValue row),
                         "partitioning_value:" <+> prettyJSON (partitioningValue row)
                       ]
-
-            chunksOf :: Int -> [a] -> [[a]]
-            chunksOf _ [] = []
-            chunksOf n xs = let (chunk, rest) = splitAt n xs in chunk : chunksOf n rest
-
-            lastElem :: [a] -> a
-            lastElem [] = error "lastElem: empty list"
-            lastElem [x] = x
-            lastElem (_ : xs) = lastElem xs
 
 -- | Columns in the order they will be queried.
 columns :: PostgreSQL -> [Text]

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -1,46 +1,46 @@
 module Ambar.Emulator.Connector.Postgres
-  ( PostgreSQL (..),
-    PostgreSQLState (..),
-  )
-where
+  ( PostgreSQL(..)
+  , PostgreSQLState
+  ) where
 
-import Ambar.Emulator.Connector qualified as C
-import Ambar.Emulator.Connector.Poll (Boundaries (..), BoundaryTracker, EntryId (..), PollingInterval, Stream)
-import Ambar.Emulator.Connector.Poll qualified as Poll
-import Ambar.Emulator.Queue.Topic (Producer, hashPartitioner)
-import Ambar.Record (Bytes (..), Record (..), TimeStamp (..), Value (..))
-import Ambar.Record.Encoding qualified as Encoding
 import Control.Concurrent.STM (STM, TVar, newTVarIO, readTVar)
-import Control.Exception (ErrorCall (..), bracket, throwIO)
+import Control.Exception (bracket, throwIO, ErrorCall(..))
 import Control.Monad (foldM)
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Aeson qualified as Aeson
+import qualified Data.Aeson as Aeson
 import Data.ByteString (ByteString)
-import Data.ByteString.Lazy qualified as LB
-import Data.Default (Default (..))
+import qualified Data.ByteString.Lazy as LB
+import Data.Default (Default(..))
 import Data.List ((\\))
 import Data.List.Extra (chunksOf)
 import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
+import qualified Data.Map.Strict as Map
 import Data.String (fromString)
-import Data.Text (Text)
-import Data.Text qualified as Text
-import Data.Text.Encoding qualified as Text (decodeUtf8)
 import Data.Time.LocalTime (localTimeToUTC, utc)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text (decodeUtf8)
 import Data.Void (Void)
 import Data.Word (Word16)
-import Database.PostgreSQL.Simple qualified as P
-import Database.PostgreSQL.Simple.FromField qualified as P
-import Database.PostgreSQL.Simple.FromRow qualified as P
-import Database.PostgreSQL.Simple.Transaction qualified as P
+import qualified Database.PostgreSQL.Simple as P
+import qualified Database.PostgreSQL.Simple.Transaction as P
+import qualified Database.PostgreSQL.Simple.FromField as P
+import qualified Database.PostgreSQL.Simple.FromRow as P
 import GHC.Generics (Generic)
+import Util.Prettyprinter (renderPretty, sepBy, commaSeparated, prettyJSON)
 import Prettyprinter (pretty, (<+>))
-import Prettyprinter qualified as Pretty
+import qualified Prettyprinter as Pretty
+
+import qualified Ambar.Emulator.Connector.Poll as Poll
+import qualified Ambar.Emulator.Connector as C
+import Ambar.Emulator.Connector.Poll (BoundaryTracker, Boundaries(..), EntryId(..), Stream, PollingInterval)
+import Ambar.Emulator.Queue.Topic (Producer, hashPartitioner)
+import Ambar.Record (Record(..), Value(..), Bytes(..), TimeStamp(..))
+import qualified Ambar.Record.Encoding as Encoding
 import Util.Async (withAsyncThrow)
 import Util.Delay (Duration, millis, seconds)
 import Util.Logger (SimpleLogger, logDebug, logInfo)
-import Util.Prettyprinter (commaSeparated, prettyJSON, renderPretty, sepBy)
 
 _POLLING_INTERVAL :: Duration
 _POLLING_INTERVAL = millis 50
@@ -52,16 +52,16 @@ _MAX_BOUNDARY_BATCH_SIZE :: Int
 _MAX_BOUNDARY_BATCH_SIZE = 500
 
 data PostgreSQL = PostgreSQL
-  { c_host :: Text,
-    c_port :: Word16,
-    c_username :: Text,
-    c_password :: Text,
-    c_database :: Text,
-    c_table :: Text,
-    c_columns :: [Text],
-    c_partitioningColumn :: Text,
-    c_serialColumn :: Text,
-    c_pollingInterval :: PollingInterval
+  { c_host :: Text
+  , c_port :: Word16
+  , c_username :: Text
+  , c_password :: Text
+  , c_database :: Text
+  , c_table :: Text
+  , c_columns :: [Text]
+  , c_partitioningColumn :: Text
+  , c_serialColumn :: Text
+  , c_pollingInterval :: PollingInterval
   }
 
 instance C.Connector PostgreSQL where
@@ -76,8 +76,8 @@ instance C.Connector PostgreSQL where
 
   connect = connect
 
-newtype TableSchema = TableSchema {unTableSchema :: Map Text PgType}
-  deriving (Show)
+newtype TableSchema = TableSchema { unTableSchema :: Map Text PgType }
+  deriving Show
 
 -- | Supported PostgreSQL types
 data PgType
@@ -117,151 +117,133 @@ newtype PostgreSQLState = PostgreSQLState BoundaryTracker
   deriving newtype (Default)
   deriving anyclass (FromJSON, ToJSON)
 
-connect ::
-  PostgreSQL ->
-  SimpleLogger ->
-  PostgreSQLState ->
-  Producer Record ->
-  (STM PostgreSQLState -> IO a) ->
-  IO a
-connect config@PostgreSQL {..} logger (PostgreSQLState tracker) producer f =
-  bracket open P.close $ \conn -> do
-    schema <- fetchSchema c_table conn
-    validate config schema
-    trackerVar <- newTVarIO tracker
-    let readState = PostgreSQLState <$> readTVar trackerVar
-    withAsyncThrow (consume conn c_pollingInterval schema trackerVar) (f readState)
-  where
-    open =
-      P.connect
-        P.ConnectInfo
-          { P.connectHost = Text.unpack c_host,
-            P.connectPort = c_port,
-            P.connectUser = Text.unpack c_username,
-            P.connectPassword = Text.unpack c_password,
-            P.connectDatabase = Text.unpack c_database
+connect
+  :: PostgreSQL
+  -> SimpleLogger
+  -> PostgreSQLState
+  -> Producer Record
+  -> (STM PostgreSQLState -> IO a)
+  -> IO a
+connect config@PostgreSQL{..} logger (PostgreSQLState tracker) producer f =
+   bracket open P.close $ \conn -> do
+   schema <- fetchSchema c_table conn
+   validate config schema
+   trackerVar <- newTVarIO tracker
+   let readState = PostgreSQLState <$> readTVar trackerVar
+   withAsyncThrow (consume conn c_pollingInterval schema trackerVar) (f readState)
+   where
+   open = P.connect P.ConnectInfo
+      { P.connectHost = Text.unpack c_host
+      , P.connectPort = c_port
+      , P.connectUser = Text.unpack c_username
+      , P.connectPassword = Text.unpack c_password
+      , P.connectDatabase = Text.unpack c_database
+      }
+
+   consume
+      :: P.Connection
+      -> PollingInterval
+      -> TableSchema
+      -> TVar BoundaryTracker
+      -> IO Void
+   consume conn interval schema trackerVar = Poll.connect trackerVar pc
+     where
+     pc = Poll.PollingConnector
+        { Poll.c_getId = entryId
+        , Poll.c_poll = run
+        , Poll.c_pollingInterval = interval
+        , Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME
+        , Poll.c_producer = producer
+        }
+
+     parser = mkParser (columns config) schema
+
+     run :: Boundaries -> Stream Record
+     run (Boundaries bs) acc0 emit =
+       P.withTransactionMode txMode conn $ do
+         let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
+         case batches of
+           [] ->
+             runBatch Nothing Nothing [] acc0
+           _ -> do
+             let initBatches = init batches
+                 lastBatch = last batches
+             (acc, mLastUpper) <-
+               foldM
+                 (\(acc, mLower) batch -> do
+                     let upper = snd (last batch)
+                     acc' <- runBatch mLower (Just upper) batch acc
+                     return (acc', Just upper)
+                 )
+                 (acc0, Nothing)
+                 initBatches
+             -- last batch has no upper bound
+             runBatch mLastUpper Nothing lastBatch acc
+       where
+       txMode = P.TransactionMode
+          { P.isolationLevel = P.ReadCommitted
+          , P.readWriteMode = P.ReadOnly
           }
 
-    consume ::
-      P.Connection ->
-      PollingInterval ->
-      TableSchema ->
-      TVar BoundaryTracker ->
-      IO Void
-    consume conn interval schema trackerVar = Poll.connect trackerVar pc
-      where
-        pc =
-          Poll.PollingConnector
-            { Poll.c_getId = entryId,
-              Poll.c_poll = run,
-              Poll.c_pollingInterval = interval,
-              Poll.c_maxTransactionTime = _MAX_TRANSACTION_TIME,
-              Poll.c_producer = producer
-            }
+       runBatch mLower mUpper batchBs acc = do
+         logDebug logger batchQuery
+         rows <- P.queryWith_ parser conn (fromString batchQuery)
+         logDebug logger $ "results: " <> show (length rows)
+         foldM
+           (\a record -> do
+               logResult record
+               emit a record
+           )
+           acc
+           rows
+         where
+         batchQuery = fromString $ Text.unpack $ renderPretty $ Pretty.fillSep
+            [ "SELECT" , commaSeparated $ map pretty $ columns config
+            , "FROM" , pretty c_table
+            , if null allConstraints then "" else "WHERE" <+> sepBy "AND" allConstraints
+            , "ORDER BY" , pretty c_serialColumn
+            ]
 
-        parser = mkParser (columns config) schema
+         allConstraints = lowerBound ++ upperBound ++ exclusions
 
-        run :: Boundaries -> Stream Record
-        run (Boundaries bs) acc0 emit =
-          P.withTransactionMode txMode conn $ do
-            let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
-            case batches of
-              [] ->
-                runBatch Nothing Nothing [] acc0
-              _ -> do
-                let initBatches = init batches
-                    lastBatch = last batches
-                (acc, mLastUpper) <-
-                  foldM
-                    ( \(acc, mLower) batch -> do
-                        let upper = snd (last batch)
-                        acc' <- runBatch mLower (Just upper) batch acc
-                        return (acc', Just upper)
-                    )
-                    (acc0, Nothing)
-                    initBatches
-                -- last batch has no upper bound
-                runBatch mLastUpper Nothing lastBatch acc
-          where
-            txMode =
-              P.TransactionMode
-                { P.isolationLevel = P.ReadCommitted,
-                  P.readWriteMode = P.ReadOnly
-                }
+         lowerBound = case mLower of
+           Nothing -> []
+           Just (EntryId low) ->
+             [Pretty.fillSep [pretty low, "<", pretty c_serialColumn]]
 
-            runBatch mLower mUpper batchBs acc = do
-              logDebug logger batchQuery
-              rows <- P.queryWith_ parser conn (fromString batchQuery)
-              logDebug logger $ "results: " <> show (length rows)
-              foldM
-                ( \a record -> do
-                    logResult record
-                    emit a record
-                )
-                acc
-                rows
-              where
-                batchQuery =
-                  fromString $
-                    Text.unpack $
-                      renderPretty $
-                        Pretty.fillSep
-                          [ "SELECT",
-                            commaSeparated $ map pretty $ columns config,
-                            "FROM",
-                            pretty c_table,
-                            if null allConstraints then "" else "WHERE" <+> sepBy "AND" allConstraints,
-                            "ORDER BY",
-                            pretty c_serialColumn
-                          ]
+         upperBound = case mUpper of
+           Nothing -> []
+           Just (EntryId high) ->
+             [Pretty.fillSep [pretty c_serialColumn, "<=", pretty high]]
 
-                allConstraints = lowerBound ++ upperBound ++ exclusions
+         exclusions =
+            [ Pretty.fillSep
+               [ "("
+               , pretty c_serialColumn, "<", pretty low
+               , "OR"
+               ,  pretty high, "<", pretty c_serialColumn
+               , ")"]
+            | (EntryId low, EntryId high) <- batchBs
+            ]
 
-                lowerBound = case mLower of
-                  Nothing -> []
-                  Just (EntryId low) ->
-                    [Pretty.fillSep [pretty low, "<", pretty c_serialColumn]]
-
-                upperBound = case mUpper of
-                  Nothing -> []
-                  Just (EntryId high) ->
-                    [Pretty.fillSep [pretty c_serialColumn, "<=", pretty high]]
-
-                exclusions =
-                  [ Pretty.fillSep
-                      [ "(",
-                        pretty c_serialColumn,
-                        "<",
-                        pretty low,
-                        "OR",
-                        pretty high,
-                        "<",
-                        pretty c_serialColumn,
-                        ")"
-                      ]
-                  | (EntryId low, EntryId high) <- batchBs
-                  ]
-
-            logResult row =
-              logInfo logger $
-                renderPretty $
-                  "ingested."
-                    <+> commaSeparated
-                      [ "serial_value:" <+> prettyJSON (serialValue row),
-                        "partitioning_value:" <+> prettyJSON (partitioningValue row)
-                      ]
+       logResult row =
+        logInfo logger $ renderPretty $
+          "ingested." <+> commaSeparated
+            [ "serial_value:" <+> prettyJSON (serialValue row)
+            , "partitioning_value:" <+> prettyJSON (partitioningValue row)
+            ]
 
 -- | Columns in the order they will be queried.
 columns :: PostgreSQL -> [Text]
-columns PostgreSQL {..} =
-  [c_serialColumn, c_partitioningColumn]
-    <> ((c_columns \\ [c_serialColumn]) \\ [c_partitioningColumn])
+columns PostgreSQL{..} =
+  [c_serialColumn, c_partitioningColumn] <>
+    ((c_columns \\ [c_serialColumn]) \\ [c_partitioningColumn])
 
 serialValue :: Record -> Value
 serialValue (Record row) =
   case row of
     [] -> error "serialValue: empty row"
-    (_, x) : _ -> x
+    (_,x):_ -> x
 
 partitioningValue :: Record -> Value
 partitioningValue (Record row) = snd $ row !! 1
@@ -269,86 +251,88 @@ partitioningValue (Record row) = snd $ row !! 1
 mkParser :: [Text] -> TableSchema -> P.RowParser Record
 mkParser cols (TableSchema schema) = Record . zip cols <$> traverse (parser . getType) cols
   where
-    getType col = schema Map.! col
+  getType col = schema Map.! col
 
-    parser :: PgType -> P.RowParser Value
-    parser ty = fmap (fromMaybe Null) $ case ty of
-      PgInt8 -> fmap Int <$> P.field
-      PgInt2 -> fmap Int <$> P.field
-      PgInt4 -> fmap Int <$> P.field
-      PgFloat4 -> fmap Real <$> P.field
-      PgFloat8 -> fmap Real <$> P.field
-      PgBool -> fmap Boolean <$> P.field
-      PgJson -> do
-        -- this JSON type is untyped and therefore is conveyed as string
-        val <- P.field @Aeson.Value
-        let txt = Text.decodeUtf8 $ LB.toStrict $ Aeson.encode val
-        return (Just $ String txt)
-      PgBytea -> fmap (Binary . Bytes . P.fromBinary) <$> P.field
-      PgTimestamp -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStamp)
-      PgTimestamptz -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStampTZ)
-      PgText -> fmap String <$> P.field
+  parser :: PgType -> P.RowParser Value
+  parser ty = fmap (fromMaybe Null) $ case ty of
+    PgInt8 -> fmap Int <$> P.field
+    PgInt2 -> fmap Int <$> P.field
+    PgInt4 -> fmap Int <$> P.field
+    PgFloat4 -> fmap Real <$> P.field
+    PgFloat8 -> fmap Real <$> P.field
+    PgBool -> fmap Boolean <$> P.field
+    PgJson -> do
+      -- this JSON type is untyped and therefore is conveyed as string
+      val <- P.field @Aeson.Value
+      let txt = Text.decodeUtf8 $ LB.toStrict $ Aeson.encode val
+      return (Just $ String txt)
+    PgBytea -> fmap (Binary . Bytes . P.fromBinary) <$> P.field
+    PgTimestamp -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStamp)
+    PgTimestamptz -> fmap DateTime <$> P.fieldWith (P.optionalField parserTimeStampTZ)
+    PgText -> fmap String <$> P.field
 
 parserTimeStampTZ :: P.FieldParser TimeStamp
 parserTimeStampTZ = parser
   where
-    parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
-    parser field mbs =
-      case mbs of
-        Nothing -> P.returnError P.UnexpectedNull field ""
-        Just bs -> do
-          let txt = Text.decodeUtf8 bs
-          utcTime <- P.fromField field mbs
-          return $ TimeStamp txt utcTime
+  parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
+  parser field mbs =
+    case mbs of
+      Nothing -> P.returnError P.UnexpectedNull field ""
+      Just bs -> do
+        let txt = Text.decodeUtf8 bs
+        utcTime <- P.fromField field mbs
+        return $ TimeStamp txt utcTime
 
 parserTimeStamp :: P.FieldParser TimeStamp
 parserTimeStamp = parser
   where
-    parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
-    parser field mbs =
-      case mbs of
-        Nothing -> P.returnError P.UnexpectedNull field ""
-        Just bs -> do
-          let txt = Text.decodeUtf8 bs
-          localTime <- P.fromField field mbs
-          return $ TimeStamp txt $ Just $ localTimeToUTC utc localTime
+  parser :: P.Field -> Maybe ByteString -> P.Conversion TimeStamp
+  parser field mbs =
+    case mbs of
+      Nothing -> P.returnError P.UnexpectedNull field ""
+      Just bs -> do
+        let txt = Text.decodeUtf8 bs
+        localTime <- P.fromField field mbs
+        return $ TimeStamp txt $ Just $ localTimeToUTC utc localTime
 
 entryId :: Record -> EntryId
 entryId record = case serialValue record of
-  Int n -> EntryId $ fromIntegral n
-  val -> error "Invalid serial column value:" (show val)
+   Int n -> EntryId $ fromIntegral n
+   val -> error "Invalid serial column value:" (show val)
 
 validate :: PostgreSQL -> TableSchema -> IO ()
 validate config (TableSchema schema) = do
   missingCol
   invalidSerial
   where
-    missing = filter (not . (`Map.member` schema)) (columns config)
-    missingCol =
-      case missing of
-        [] -> return ()
-        xs -> throwIO $ ErrorCall $ "Missing columns in target table: " <> Text.unpack (Text.unwords xs)
+  missing = filter (not . (`Map.member` schema)) (columns config)
+  missingCol =
+    case missing of
+      [] -> return ()
+      xs -> throwIO $ ErrorCall $ "Missing columns in target table: " <> Text.unpack (Text.unwords xs)
 
-    invalidSerial =
-      if serialTy `elem` allowedSerialTypes
-        then return ()
-        else throwIO $ ErrorCall $ "Invalid serial column type: " <> show serialTy
-    serialTy = schema Map.! c_serialColumn config
-    allowedSerialTypes = [PgInt8, PgInt2, PgInt4]
+  invalidSerial =
+    if serialTy `elem` allowedSerialTypes
+    then return ()
+    else throwIO $ ErrorCall $ "Invalid serial column type: " <> show serialTy
+  serialTy = schema Map.! c_serialColumn config
+  allowedSerialTypes = [PgInt8, PgInt2, PgInt4]
 
 fetchSchema :: Text -> P.Connection -> IO TableSchema
 fetchSchema table conn = do
-  cols <- P.query conn query [table]
-  return $ TableSchema $ Map.fromList cols
-  where
-    -- In PostgreSQL internals 'columns' are called 'attributes' for hysterical raisins.
-    -- oid is the table identifier in the pg_class table.
-    query =
-      fromString $
-        unwords
-          [ "SELECT a.attname, t.typname",
-            "  FROM pg_class c",
-            "  JOIN pg_attribute a ON relname = ? AND c.oid = a.attrelid AND a.attnum > 0",
-            "  JOIN pg_type t ON t.oid = a.atttypid",
-            "  ORDER BY a.attnum ASC;"
-          ]
+   cols <- P.query conn query [table]
+   return $ TableSchema $ Map.fromList cols
+   where
+   -- In PostgreSQL internals 'columns' are called 'attributes' for hysterical raisins.
+   -- oid is the table identifier in the pg_class table.
+   query = fromString $ unwords
+      [ "SELECT a.attname, t.typname"
+      , "  FROM pg_class c"
+      , "  JOIN pg_attribute a ON relname = ? AND c.oid = a.attrelid AND a.attnum > 0"
+      , "  JOIN pg_type t ON t.oid = a.atttypid"
+      , "  ORDER BY a.attnum ASC;"
+      ]
+
+
+
+

--- a/src/Ambar/Emulator/Connector/Postgres.hs
+++ b/src/Ambar/Emulator/Connector/Postgres.hs
@@ -1,10 +1,11 @@
 module Ambar.Emulator.Connector.Postgres
   ( PostgreSQL(..)
-  , PostgreSQLState
+  , PostgreSQLState(..)
   ) where
 
 import Control.Concurrent.STM (STM, TVar, newTVarIO, readTVar)
 import Control.Exception (bracket, throwIO, ErrorCall(..))
+import Control.Monad (foldM)
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.Aeson as Aeson
 import Data.ByteString (ByteString)
@@ -45,6 +46,9 @@ _POLLING_INTERVAL = millis 50
 
 _MAX_TRANSACTION_TIME :: Duration
 _MAX_TRANSACTION_TIME = seconds 120
+
+_MAX_BOUNDARY_BATCH_SIZE :: Int
+_MAX_BOUNDARY_BATCH_SIZE = 500
 
 
 data PostgreSQL = PostgreSQL
@@ -164,31 +168,53 @@ connect config@PostgreSQL{..} logger (PostgreSQLState tracker) producer f =
 
      run :: Boundaries -> Stream Record
      run (Boundaries bs) acc0 emit = do
-       logDebug logger query
-       (acc, count) <- P.foldWithOptionsAndParser opts parser conn (fromString query) () (acc0, 0) $
-         \(acc, !count) record -> do
-           logResult record
-           acc' <- emit acc record
-           return (acc', succ count)
-       logDebug logger $ "results: " <> show @Int count
-       return acc
+       let batches = chunksOf _MAX_BOUNDARY_BATCH_SIZE bs
+       (acc, mLastUpper) <- foldM
+         (\(acc, mLower) batch -> do
+           let upper = snd (lastElem batch)
+           acc' <- runBatch mLower (Just upper) batch acc
+           return (acc', Just upper)
+         ) (acc0, Nothing) batches
+       runBatch mLastUpper Nothing [] acc
        where
-       query = fromString $ Text.unpack $ renderPretty $ Pretty.fillSep
-          [ "SELECT" , commaSeparated $ map pretty $ columns config
-          , "FROM" , pretty c_table
-          , if null bs then "" else "WHERE" <> constraints
-          , "ORDER BY" , pretty c_serialColumn
-          ]
+       runBatch mLower mUpper batchBs acc = do
+         logDebug logger batchQuery
+         (acc', count) <- P.foldWithOptionsAndParser opts parser conn (fromString batchQuery) () (acc, 0) $
+           \(a, !count) record -> do
+             logResult record
+             a' <- emit a record
+             return (a', succ count)
+         logDebug logger $ "results: " <> show @Int count
+         return acc'
+         where
+         batchQuery = fromString $ Text.unpack $ renderPretty $ Pretty.fillSep
+            [ "SELECT" , commaSeparated $ map pretty $ columns config
+            , "FROM" , pretty c_table
+            , if null allConstraints then "" else "WHERE" <+> sepBy "AND" allConstraints
+            , "ORDER BY" , pretty c_serialColumn
+            ]
 
-       constraints = sepBy "AND"
-          [ Pretty.fillSep
-             [ "("
-             , pretty c_serialColumn, "<", pretty low
-             , "OR"
-             ,  pretty high, "<", pretty c_serialColumn
-             , ")"]
-          | (EntryId low, EntryId high) <- bs
-          ]
+         allConstraints = lowerBound ++ upperBound ++ exclusions
+
+         lowerBound = case mLower of
+           Nothing -> []
+           Just (EntryId low) ->
+             [Pretty.fillSep [pretty low, "<", pretty c_serialColumn]]
+
+         upperBound = case mUpper of
+           Nothing -> []
+           Just (EntryId high) ->
+             [Pretty.fillSep [pretty c_serialColumn, "<=", pretty high]]
+
+         exclusions =
+            [ Pretty.fillSep
+               [ "("
+               , pretty c_serialColumn, "<", pretty low
+               , "OR"
+               ,  pretty high, "<", pretty c_serialColumn
+               , ")"]
+            | (EntryId low, EntryId high) <- batchBs
+            ]
 
        logResult row =
         logInfo logger $ renderPretty $
@@ -196,6 +222,15 @@ connect config@PostgreSQL{..} logger (PostgreSQLState tracker) producer f =
             [ "serial_value:" <+> prettyJSON (serialValue row)
             , "partitioning_value:" <+> prettyJSON (partitioningValue row)
             ]
+
+       chunksOf :: Int -> [a] -> [[a]]
+       chunksOf _ [] = []
+       chunksOf n xs = let (chunk, rest) = splitAt n xs in chunk : chunksOf n rest
+
+       lastElem :: [a] -> a
+       lastElem [] = error "lastElem: empty list"
+       lastElem [x] = x
+       lastElem (_:xs) = lastElem xs
 
 -- | Columns in the order they will be queried.
 columns :: PostgreSQL -> [Text]

--- a/tests/Test/Connector/PostgreSQL.hs
+++ b/tests/Test/Connector/PostgreSQL.hs
@@ -38,8 +38,8 @@ import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
 
 import qualified Ambar.Emulator.Connector as Connector
-import Ambar.Emulator.Connector.Postgres (PostgreSQL(..), PostgreSQLState(..))
-import Ambar.Emulator.Connector.Poll (PollingInterval(..), BoundaryTracker, mark)
+import Ambar.Emulator.Connector.Postgres (PostgreSQL(..))
+import Ambar.Emulator.Connector.Poll (PollingInterval(..))
 import Ambar.Emulator.Queue.Topic (Topic, PartitionCount(..))
 import qualified Ambar.Emulator.Queue.Topic as Topic
 import Ambar.Record (Bytes(..))
@@ -48,8 +48,6 @@ import Util.OnDemand (OnDemand)
 import Test.Util.SQL
 import qualified Util.OnDemand as OnDemand
 
-import Data.Default (def)
-import Data.Time.Clock.POSIX (getPOSIXTime)
 import Util.Delay (deadline, seconds, delay, millis)
 
 testPostgreSQL :: OnDemand PostgresCreds -> Spec
@@ -58,17 +56,17 @@ testPostgreSQL p = do
     testGenericSQL with
 
     it "handles large boundary lists" $ do
-      now <- getPOSIXTime
-      let tracker = foldl (\t i -> mark now (i * 2 + 1) t) (def :: BoundaryTracker) [0..4999]
-          state = PostgreSQLState tracker
-      withConnectorState @(EventsTable PostgreSQL) p withConnection mkPostgreSQL () (PartitionCount 1) state $
-        \conn table topic connected -> do
-        -- Insert a row that will have a serial id beyond the boundary range
-        insert conn table (take 2 $ head $ mocks table)
+      with (PartitionCount 1) $ \conn table topic connected -> do
+        void $ P.execute_ conn
+          (fromString $ "ALTER SEQUENCE " <> tableName table <> "_id_seq INCREMENT BY 2")
+        let n = 10000
+        insert conn table (take n $ head $ mocks table)
         connected $
-          deadline (seconds 5) $
+          deadline (seconds 10) $
           Topic.withConsumer topic group $ \consumer -> do
-          void $ readEntry @Event consumer
+            forM_ [1..n] $ \_ -> void $ readEntry @Event consumer
+            insert conn table [head (mocks table !! 1)]
+            void $ readEntry @Event consumer
 
     -- Test that column types are supported/unsupported by
     -- creating database entries with the value and reporting

--- a/tests/Test/Connector/PostgreSQL.hs
+++ b/tests/Test/Connector/PostgreSQL.hs
@@ -38,8 +38,8 @@ import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
 
 import qualified Ambar.Emulator.Connector as Connector
-import Ambar.Emulator.Connector.Postgres (PostgreSQL(..))
-import Ambar.Emulator.Connector.Poll (PollingInterval(..))
+import Ambar.Emulator.Connector.Postgres (PostgreSQL(..), PostgreSQLState(..))
+import Ambar.Emulator.Connector.Poll (PollingInterval(..), BoundaryTracker, mark)
 import Ambar.Emulator.Queue.Topic (Topic, PartitionCount(..))
 import qualified Ambar.Emulator.Queue.Topic as Topic
 import Ambar.Record (Bytes(..))
@@ -48,12 +48,27 @@ import Util.OnDemand (OnDemand)
 import Test.Util.SQL
 import qualified Util.OnDemand as OnDemand
 
+import Data.Default (def)
+import Data.Time.Clock.POSIX (getPOSIXTime)
 import Util.Delay (deadline, seconds, delay, millis)
 
 testPostgreSQL :: OnDemand PostgresCreds -> Spec
 testPostgreSQL p = do
   describe "PostgreSQL" $ do
     testGenericSQL with
+
+    it "handles large boundary lists" $ do
+      now <- getPOSIXTime
+      let tracker = foldl (\t i -> mark now (i * 2 + 1) t) (def :: BoundaryTracker) [0..4999]
+          state = PostgreSQLState tracker
+      withConnectorState @(EventsTable PostgreSQL) p withConnection mkPostgreSQL () (PartitionCount 1) state $
+        \conn table topic connected -> do
+        -- Insert a row that will have a serial id beyond the boundary range
+        insert conn table (take 2 $ head $ mocks table)
+        connected $
+          deadline (seconds 5) $
+          Topic.withConsumer topic group $ \consumer -> do
+          void $ readEntry @Event consumer
 
     -- Test that column types are supported/unsupported by
     -- creating database entries with the value and reporting

--- a/tests/Test/Util/SQL.hs
+++ b/tests/Test/Util/SQL.hs
@@ -5,6 +5,7 @@ module Test.Util.SQL
   , testGenericSQL
   , mkTableName
   , withConnector
+  , withConnectorState
   , group
   , readEntry
 
@@ -178,6 +179,28 @@ withConnector od withConnection mkConfig conf partitions f =
       connected act = connect config logger def producer (const act) -- setup connector
   f conn table topic connected
 
+-- | Like 'withConnector' but accepts an explicit initial 'ConnectorState'.
+withConnectorState
+  :: (Table table, Connector connector)
+  => OnDemand db
+  -> (forall x. db -> (Connection table -> IO x) -> IO x)
+  -> (db -> table -> connector)
+  -> Config table
+  -> PartitionCount
+  -> ConnectorState connector
+  -> (Connection table -> table -> Topic -> (IO b -> IO b) -> IO a)
+  -> IO a
+withConnectorState od withConnection mkConfig conf partitions state f =
+  OnDemand.with od $ \db ->
+  withConnection db $ \conn ->
+  withTable conf conn $ \table ->
+  withFileTopic partitions $ \topic ->
+  Topic.withProducer topic partitioner encoder $ \producer -> do
+  let logger = plainLogger Warn
+      config = mkConfig db table
+      connected :: forall x. IO x -> IO x
+      connected act = connect config logger state producer (const act)
+  f conn table topic connected
 
 {-# NOINLINE tableNumber #-}
 tableNumber :: MVar Int

--- a/tests/Test/Util/SQL.hs
+++ b/tests/Test/Util/SQL.hs
@@ -178,6 +178,7 @@ withConnector od withConnection mkConfig conf partitions f =
       connected act = connect config logger def producer (const act) -- setup connector
   f conn table topic connected
 
+
 {-# NOINLINE tableNumber #-}
 tableNumber :: MVar Int
 tableNumber = unsafePerformIO (newMVar 0)

--- a/tests/Test/Util/SQL.hs
+++ b/tests/Test/Util/SQL.hs
@@ -5,7 +5,6 @@ module Test.Util.SQL
   , testGenericSQL
   , mkTableName
   , withConnector
-  , withConnectorState
   , group
   , readEntry
 
@@ -177,29 +176,6 @@ withConnector od withConnection mkConfig conf partitions f =
       config = mkConfig db table
       connected :: forall x. IO x -> IO x
       connected act = connect config logger def producer (const act) -- setup connector
-  f conn table topic connected
-
--- | Like 'withConnector' but accepts an explicit initial 'ConnectorState'.
-withConnectorState
-  :: (Table table, Connector connector)
-  => OnDemand db
-  -> (forall x. db -> (Connection table -> IO x) -> IO x)
-  -> (db -> table -> connector)
-  -> Config table
-  -> PartitionCount
-  -> ConnectorState connector
-  -> (Connection table -> table -> Topic -> (IO b -> IO b) -> IO a)
-  -> IO a
-withConnectorState od withConnection mkConfig conf partitions state f =
-  OnDemand.with od $ \db ->
-  withConnection db $ \conn ->
-  withTable conf conn $ \table ->
-  withFileTopic partitions $ \topic ->
-  Topic.withProducer topic partitioner encoder $ \producer -> do
-  let logger = plainLogger Warn
-      config = mkConfig db table
-      connected :: forall x. IO x -> IO x
-      connected act = connect config logger state producer (const act)
   f conn table topic connected
 
 {-# NOINLINE tableNumber #-}


### PR DESCRIPTION
The Postgres boundary query was already operating in a transaciton, so all that was necessary was chunking the constraints to prevent the query size from growing unmangeable.

In true TDD style, I added a test that failed before this fix; batching the query causes the test to pass.